### PR TITLE
Review and fix tool selection logic

### DIFF
--- a/packages/app/src/server/mcp-proxy.ts
+++ b/packages/app/src/server/mcp-proxy.ts
@@ -129,15 +129,16 @@ export const createProxyServerFactory = (
 		const noImageFromSettings = settings?.builtInTools?.includes(GRADIO_IMAGE_FILTER_FLAG) ?? false;
 		const stripImageContent = noImageFromHeader || noImageFromSettings;
 
-		// Skip Gradio endpoints if bouquet is not "all"
-		if (bouquet && bouquet !== 'all') {
-			logger.debug({ bouquet }, 'Bouquet specified and not "all", skipping Gradio endpoints');
-			return result;
-		}
-
 		// Skip Gradio endpoints if explicitly disabled
 		if (gradio === 'none') {
 			logger.debug('Gradio endpoints explicitly disabled via gradio="none"');
+			return result;
+		}
+
+		// Skip Gradio endpoints from settings if bouquet is specified (not "all") and no explicit gradio param
+		// This allows: bouquet=search&gradio=foo/bar to work as expected
+		if (bouquet && bouquet !== 'all' && !gradio) {
+			logger.debug({ bouquet }, 'Bouquet specified (not "all") and no explicit gradio param, skipping Gradio endpoints from settings');
 			return result;
 		}
 


### PR DESCRIPTION
This combines the best of both approaches:
- Uses the smarter conditional logic from fix branch (checks !gradio)
- Adds comprehensive documentation from review branch
- Includes extensive tests for gradio endpoint handling

Key changes:
- Modified mcp-proxy.ts to allow explicit gradio= param with any bouquet
- Enhanced documentation explaining the two independent systems
- Added 6 new test cases for gradio endpoint handling

The logic now correctly handles:
- bouquet=search&gradio=foo/bar → includes foo/bar endpoint ✓
- bouquet=search (no gradio) → no gradio endpoints ✓
- bouquet=all → includes gradio endpoints from settings ✓