### PR TITLE
Debug gradio_files tool invocation issue

### DIFF
--- a/packages/app/src/server/transport/base-transport.ts
+++ b/packages/app/src/server/transport/base-transport.ts
@@ -267,10 +267,28 @@ export abstract class BaseTransport {
 			return true;
 		}
 
-		// For tools/call, check if it's a Gradio tool using the dedicated method
+		// For tools/call, check if it's a Gradio-related tool
 		if (methodName === 'tools/call') {
-			// Return true (skip) for non-Gradio tools, false (don't skip) for Gradio tools
-			return !this.isGradioToolCall(requestBody);
+			const toolName = body?.params?.name;
+			if (typeof toolName === 'string') {
+				// Don't skip for Gradio tools (need streaming)
+				if (this.isGradioToolCall(requestBody)) {
+					return false;
+				}
+
+				// Don't skip for gradio_files (needs proxy registration but not streaming)
+				if (toolName === 'gradio_files') {
+					return false;
+				}
+
+				// Don't skip for dynamic_space (all operations need proxy registration)
+				if (toolName === 'dynamic_space') {
+					return false;
+				}
+			}
+
+			// Skip for all other tools
+			return true;
 		}
 
 		// For other methods, don't skip Gradio (conservative default)


### PR DESCRIPTION
The gradio_files tool was failing to invoke because skipGradioSetup was returning true for it, causing the proxy factory to skip registration.

Root cause:
- Commit 6842a47 removed gradio_files from isGradioTool() to avoid streaming
- This caused skipGradioSetup to return true (skip) for gradio_files calls
- The proxy factory would exit early and never register the gradio_files tool
- Tool invocation would fail because the tool wasn't registered

Solution:
- Add explicit check in skipGradioSetup for gradio_files
- Return false (don't skip) to ensure proxy registration happens
- Keep gradio_files OUT of isGradioToolCall to maintain direct response (no streaming)

This ensures gradio_files gets registered but doesn't use streaming, which matches the original intent of commit 6842a47.