### PR TITLE
Fix broken gradio_files tool listing

### DIFF
--- a/packages/app/src/server/transport/base-transport.ts
+++ b/packages/app/src/server/transport/base-transport.ts
@@ -9,6 +9,7 @@ import { whoAmI, HubApiError, type WhoAmI } from '@huggingface/hub';
 import { extractAuthBouquetAndMix } from '../utils/auth-utils.js';
 import { getMetricsSafeName } from '../utils/gradio-metrics.js';
 import { isGradioTool } from '../utils/gradio-utils.js';
+import { GRADIO_FILES_TOOL_CONFIG } from '@llmindset/hf-mcp';
 
 /**
  * Result returned by ServerFactory containing the server instance and optional user details
@@ -269,6 +270,13 @@ export abstract class BaseTransport {
 
 		// For tools/call, check if it's a Gradio tool using the dedicated method
 		if (methodName === 'tools/call') {
+			const toolName = body?.params?.name;
+
+			// Special case: gradio_files needs Gradio setup (for registration) but not streaming
+			if (toolName === GRADIO_FILES_TOOL_CONFIG.name) {
+				return false; // Don't skip Gradio setup
+			}
+
 			// Return true (skip) for non-Gradio tools, false (don't skip) for Gradio tools
 			return !this.isGradioToolCall(requestBody);
 		}


### PR DESCRIPTION
The gradio_files tool was broken because it was being excluded from Gradio setup after commit 6842a47 removed it from isGradioTool().

Root cause:
- isGradioTool('gradio_files') now returns false (for streaming logic)
- skipGradioSetup() was skipping ALL non-Gradio tools
- This caused the proxy factory to return early (mcp-proxy.ts:124-126)
- gradio_files was never registered (happens at mcp-proxy.ts:215-249)

Solution:
Add special case for gradio_files in skipGradioSetup() to ensure it still gets registered during the Gradio setup phase, even though it doesn't need special streaming handling.

This separates two concerns:
1. Streaming behavior (isGradioTool) - gradio_files doesn't need this
2. Registration phase (skipGradioSetup) - gradio_files DOES need this