### PR TITLE
🔒 Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,13 +10,13 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1  # v4
         with:
           version: 10.29.2
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6
         with:
           node-version: '22'
           cache: 'pnpm'
@@ -33,13 +33,13 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1  # v4
         with:
           version: 10.29.2
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6
         with:
           node-version: '22'
           cache: 'pnpm'
@@ -56,13 +56,13 @@ jobs:
   build-docker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
 
       - name: Build Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
         with:
           context: .
           push: false

--- a/.github/workflows/docker-prerelease.yml
+++ b/.github/workflows/docker-prerelease.yml
@@ -21,14 +21,14 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
 
       - name: Log in to GitHub Container Registry
         if: github.event.inputs.push_to_registry != 'false'
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -58,7 +58,7 @@ jobs:
           echo "docker_tag_latest=ghcr.io/${{ github.repository }}:${BRANCH_NAME}-latest" >> $GITHUB_OUTPUT
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
         with:
           context: .
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,15 +23,15 @@ jobs:
       contents: write
       packages: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1  # v4
         with:
           version: 10.29.2
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6
         with:
           node-version: '22'
           cache: 'pnpm'
@@ -78,7 +78,7 @@ jobs:
           git push origin --tags
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe  # v2
         with:
           tag_name: v${{ steps.version.outputs.new-version }}
           generate_release_notes: true


### PR DESCRIPTION
## 🔒 Pin GitHub Actions to commit SHAs

This PR pins all GitHub Actions to their exact commit SHA instead of mutable tags or branch names.

**Why?**
Pinning to a SHA prevents supply chain attacks where a tag (e.g. `v4`) could be moved to point to malicious code.

### Changes

| Workflow | Action | Avant | Après | SHA |
|---|---|---|---|---|
| `docker-prerelease.yml` | `actions/checkout` | `v6` | `v6.0.2` | `de0fac2e4500…` |
| `docker-prerelease.yml` | `docker/setup-buildx-action` | `v3` | `v3` | `8d2750c68a42…` |
| `docker-prerelease.yml` | `docker/login-action` | `v3` | `v3` | `c94ce9fb4685…` |
| `docker-prerelease.yml` | `docker/build-push-action` | `v6` | `v6` | `10e90e3645ea…` |
| `ci.yml` | `actions/checkout` | `v6` | `v6.0.2` | `de0fac2e4500…` |
| `ci.yml` | `pnpm/action-setup` | `v4` | `v4` | `b906affcce14…` |
| `ci.yml` | `actions/setup-node` | `v6` | `v6` | `53b83947a5a9…` |
| `ci.yml` | `actions/checkout` | `v6` | `v6.0.2` | `de0fac2e4500…` |
| `ci.yml` | `pnpm/action-setup` | `v4` | `v4` | `b906affcce14…` |
| `ci.yml` | `actions/setup-node` | `v6` | `v6` | `53b83947a5a9…` |
| `ci.yml` | `actions/checkout` | `v6` | `v6.0.2` | `de0fac2e4500…` |
| `ci.yml` | `docker/setup-buildx-action` | `v3` | `v3` | `8d2750c68a42…` |
| `ci.yml` | `docker/build-push-action` | `v6` | `v6` | `10e90e3645ea…` |
| `release.yml` | `actions/checkout` | `v6` | `v6.0.2` | `de0fac2e4500…` |
| `release.yml` | `pnpm/action-setup` | `v4` | `v4` | `b906affcce14…` |
| `release.yml` | `actions/setup-node` | `v6` | `v6` | `53b83947a5a9…` |
| `release.yml` | `softprops/action-gh-release` | `v2` | `v2` | `153bb8e04406…` |

> 🤖 Generated by `/github-actions-audit` — [security/pin-actions-to-sha]


Closes huggingface/tracking-issues#134