### PR TITLE
fix: deny resources to flooding clients (cursor-vscode DoS) + explicit subscribe:false

### DIFF
--- a/packages/app/src/server/mcp-server.ts
+++ b/packages/app/src/server/mcp-server.ts
@@ -86,6 +86,7 @@ import { createGradioWidgetResourceConfig } from './resources/gradio-widget-reso
 import { applyResultPostProcessing, type GradioToolCallOptions } from './utils/gradio-tool-caller.js';
 import { loadSkills } from './skills/skill-loader.js';
 import { registerSkillResources } from './skills/skill-resources.js';
+import { isClientDenied } from '../shared/client-denylist.js';
 import type { SkillCatalog } from './skills/skill-types.js';
 
 // Fallback settings when API fails (enables all tools)
@@ -222,7 +223,10 @@ export const createServerFactory = (_webServerInstance: WebServer, sharedApiClie
 
 		// Load the experimental skills catalog (cached across sessions). Failure leaves it null and disables skills.
 		const skillCatalog = await getSkillCatalog();
-		const hasSkills = !!skillCatalog?.skills.length;
+		// Some clients (e.g. cursor-vscode) flood the resource surface; deny them the
+		// Skills resources entirely — not registered and not advertised.
+		const clientDenied = isClientDenied(sessionInfo?.clientInfo?.name, headers?.['user-agent']);
+		const hasSkills = !!skillCatalog?.skills.length && !clientDenied;
 
 		/**
 		 *  we will set capabilities below. use of the convenience .tool() registration methods automatically
@@ -1156,7 +1160,7 @@ export const createServerFactory = (_webServerInstance: WebServer, sharedApiClie
 		const transportInfo = sharedApiClient.getTransportInfo();
 
 		registerCapabilities(server, sharedApiClient, {
-			hasResources: sessionInfo?.clientInfo?.name === 'openai-mcp',
+			hasResources: !clientDenied && sessionInfo?.clientInfo?.name === 'openai-mcp',
 			hasSkills,
 		});
 

--- a/packages/app/src/server/transport/json-rpc-errors.ts
+++ b/packages/app/src/server/transport/json-rpc-errors.ts
@@ -94,6 +94,9 @@ export const JsonRpcErrors = {
 	methodNotAllowed: (id: string | number | null = null, message: string = 'Method not allowed') =>
 		createJsonRpcError(JSON_RPC_ERROR_CODES.SERVER_ERROR, message, id),
 
+	methodNotFound: (id: string | number | null = null, message: string = 'Method not found') =>
+		createJsonRpcError(JSON_RPC_ERROR_CODES.METHOD_NOT_FOUND, message, id),
+
 	invalidRequest: (id: string | number | null = null, message: string = 'Invalid request') =>
 		createJsonRpcError(JSON_RPC_ERROR_CODES.INVALID_REQUEST, message, id),
 

--- a/packages/app/src/server/transport/stateless-http-transport.ts
+++ b/packages/app/src/server/transport/stateless-http-transport.ts
@@ -19,9 +19,16 @@ import { buildOAuthResourceHeader } from '../utils/oauth-resource.js';
 import { randomUUID } from 'node:crypto';
 import { logSystemEvent } from '../utils/query-logger.js';
 import { rewriteLegacySearchToolCallRequest } from '../utils/repo-search-shim.js';
+import { isClientDenied } from '../../shared/client-denylist.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
+
+// Resource methods that build the full server and thus expose the Skills surface.
+const RESOURCE_METHODS = new Set(['resources/list', 'resources/read', 'resources/templates/list']);
+// Resource-subscription methods we never support (skills are static — nothing to
+// notify `resources/updated` about). Rejected cheaply before any server is built.
+const UNSUPPORTED_SUBSCRIBE_METHODS = new Set(['resources/subscribe', 'resources/unsubscribe']);
 
 // Analytics session without server (server is null in analytics mode)
 interface AnalyticsSession {
@@ -62,7 +69,7 @@ export class StatelessHttpTransport extends BaseTransport {
 	 * Determines if a request should be handled by the full server
 	 * or can be handled by the stub responder
 	 */
-	private shouldHandle(requestBody: unknown, _clientName?: string): boolean {
+	private shouldHandle(requestBody: unknown, clientName?: string, userAgent?: string): boolean {
 		const body = requestBody as { method?: string } | undefined;
 		const method = body?.method;
 
@@ -78,6 +85,12 @@ export class StatelessHttpTransport extends BaseTransport {
 		]);
 
 		if (method && methodsRequiringFullServer.has(method)) {
+			// Denied clients (e.g. cursor-vscode flooding the resource surface) get no
+			// resources: route their resource list/read to the stub responder so the
+			// full Skills server is never built for them.
+			if (RESOURCE_METHODS.has(method) && isClientDenied(clientName, userAgent)) {
+				return false;
+			}
 			return true;
 		}
 
@@ -155,6 +168,17 @@ export class StatelessHttpTransport extends BaseTransport {
 			| undefined;
 
 		const trackingName = this.extractMethodForTracking(requestBody);
+
+		// Resource subscriptions are never supported (skills are static). Reject these
+		// cheaply before building any server — cursor-vscode floods `resources/subscribe`.
+		const rpcMethod = requestBody?.method;
+		if (rpcMethod && UNSUPPORTED_SUBSCRIBE_METHODS.has(rpcMethod)) {
+			this.trackMethodCall(trackingName, startTime, false);
+			res.status(200).json(
+				JsonRpcErrors.methodNotFound(extractJsonRpcId(req.body), `${rpcMethod} is not supported`)
+			);
+			return;
+		}
 
 		const authResult = await this.validateAuthAndTrackMetrics(headers);
 		if (!authResult.shouldContinue || trackingName === 'tools/call:Authenticate') {
@@ -297,8 +321,8 @@ export class StatelessHttpTransport extends BaseTransport {
 				clientInfo = extractedClientInfo;
 			}
 
-			// Determine which server to use, passing client name for resource method filtering
-			const useFullServer = this.shouldHandle(requestBody, clientInfo?.name);
+			// Determine which server to use, passing client name + user-agent for resource method filtering
+			const useFullServer = this.shouldHandle(requestBody, clientInfo?.name, headers['user-agent']);
 			let directResponse = true;
 
 			if (useFullServer) {

--- a/packages/app/src/server/utils/capability-utils.ts
+++ b/packages/app/src/server/utils/capability-utils.ts
@@ -48,6 +48,10 @@ export function registerCapabilities(
 		...(advertiseResources
 			? {
 					resources: {
+						// We do not support resource subscriptions (skills are static —
+						// nothing to notify `resources/updated` about). Advertise explicitly
+						// rather than relying on omission.
+						subscribe: false,
 						listChanged: false,
 					},
 				}

--- a/packages/app/src/shared/client-denylist.ts
+++ b/packages/app/src/shared/client-denylist.ts
@@ -1,0 +1,33 @@
+// Clients on this denylist are not offered MCP resources (the Skills surface):
+// the server advertises no `resources` capability / skills extension to them and
+// routes resource methods to the stub responder. This mitigates clients that
+// flood the server against the resource surface — notably `cursor-vscode`, which
+// retry-loops `resources/subscribe` regardless of advertised capabilities.
+
+export const DEFAULT_DENIED_CLIENTS = ['cursor-vscode'] as const;
+
+// Comma-separated. When set (even empty) it REPLACES the default list, so ops can
+// disable the denylist entirely (`MCP_RESOURCES_CLIENT_DENYLIST=`) or customise it
+// (`MCP_RESOURCES_CLIENT_DENYLIST=cursor-vscode,foo`). Unset uses the default.
+export const RESOURCES_CLIENT_DENYLIST_ENV = 'MCP_RESOURCES_CLIENT_DENYLIST' as const;
+
+export function getDeniedClients(): string[] {
+	const raw = process.env[RESOURCES_CLIENT_DENYLIST_ENV];
+	const source = raw === undefined ? DEFAULT_DENIED_CLIENTS.join(',') : raw;
+	return source
+		.split(',')
+		.map((entry) => entry.trim().toLowerCase())
+		.filter((entry) => entry.length > 0);
+}
+
+/**
+ * Whether a client should be denied the resources surface. Matches the denylist
+ * entries as case-insensitive substrings against both the MCP `clientInfo.name`
+ * and the HTTP `user-agent` (catches e.g. `cursor-vscode (via mcp-remote 0.1.37)`).
+ */
+export function isClientDenied(clientName?: string, userAgent?: string): boolean {
+	const needles = getDeniedClients();
+	if (needles.length === 0) return false;
+	const haystack = `${clientName ?? ''}\n${userAgent ?? ''}`.toLowerCase();
+	return needles.some((needle) => haystack.includes(needle));
+}

--- a/packages/app/test/server/capability-utils.test.ts
+++ b/packages/app/test/server/capability-utils.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { ServerCapabilities } from '@modelcontextprotocol/sdk/types.js';
+import { registerCapabilities } from '../../src/server/utils/capability-utils.js';
+import type { McpApiClient } from '../../src/server/utils/mcp-api-client.js';
+
+function makeServer(): { server: McpServer; getCaps: () => ServerCapabilities } {
+	let captured: ServerCapabilities = {};
+	const inner = {
+		_capabilities: {} as Record<string, unknown>,
+		registerCapabilities(caps: ServerCapabilities) {
+			captured = caps;
+		},
+	};
+	const server = { server: inner } as unknown as McpServer;
+	return { server, getCaps: () => captured };
+}
+
+const apiClient = { getTransportInfo: () => ({ jsonResponseEnabled: true }) } as unknown as McpApiClient;
+
+describe('registerCapabilities', () => {
+	it('advertises resources with explicit subscribe:false + the skills extension when skills present', () => {
+		const { server, getCaps } = makeServer();
+		registerCapabilities(server, apiClient, { hasSkills: true });
+		const caps = getCaps();
+		expect(caps.resources).toEqual({ subscribe: false, listChanged: false });
+		expect(caps.extensions).toEqual({ 'io.modelcontextprotocol/skills': {} });
+	});
+
+	it('advertises no resources or skills extension for a denied client (hasSkills/hasResources false)', () => {
+		const { server, getCaps } = makeServer();
+		registerCapabilities(server, apiClient, { hasSkills: false, hasResources: false });
+		const caps = getCaps();
+		expect(caps.resources).toBeUndefined();
+		expect(caps.extensions).toBeUndefined();
+	});
+});

--- a/packages/app/test/shared/client-denylist.test.ts
+++ b/packages/app/test/shared/client-denylist.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+	DEFAULT_DENIED_CLIENTS,
+	RESOURCES_CLIENT_DENYLIST_ENV,
+	getDeniedClients,
+	isClientDenied,
+} from '../../src/shared/client-denylist.js';
+
+const ENV = RESOURCES_CLIENT_DENYLIST_ENV;
+const original = process.env[ENV];
+
+afterEach(() => {
+	if (original === undefined) delete process.env[ENV];
+	else process.env[ENV] = original;
+});
+
+describe('client-denylist', () => {
+	it('denies cursor-vscode by default', () => {
+		delete process.env[ENV];
+		expect(DEFAULT_DENIED_CLIENTS).toContain('cursor-vscode');
+		expect(getDeniedClients()).toEqual(['cursor-vscode']);
+		expect(isClientDenied('cursor-vscode')).toBe(true);
+	});
+
+	it('matches case-insensitively and as a substring on clientInfo.name', () => {
+		delete process.env[ENV];
+		expect(isClientDenied('Cursor-VSCode')).toBe(true);
+		expect(isClientDenied('cursor-vscode (via mcp-remote 0.1.37)')).toBe(true);
+	});
+
+	it('matches on the user-agent when clientInfo.name is absent', () => {
+		delete process.env[ENV];
+		expect(isClientDenied(undefined, 'cursor-vscode (via mcp-remote 0.1.37)')).toBe(true);
+		expect(isClientDenied(undefined, 'node-fetch')).toBe(false);
+	});
+
+	it('does not deny other clients', () => {
+		delete process.env[ENV];
+		expect(isClientDenied('fast-agent-mcp')).toBe(false);
+		expect(isClientDenied('claude-ai', 'some-agent/1.0')).toBe(false);
+		expect(isClientDenied()).toBe(false);
+	});
+
+	it('env var replaces the default list (extend with more clients)', () => {
+		process.env[ENV] = 'cursor-vscode, foo-client';
+		expect(getDeniedClients()).toEqual(['cursor-vscode', 'foo-client']);
+		expect(isClientDenied('cursor-vscode')).toBe(true);
+		expect(isClientDenied('foo-client')).toBe(true);
+	});
+
+	it('empty env var disables the denylist entirely', () => {
+		process.env[ENV] = '';
+		expect(getDeniedClients()).toEqual([]);
+		expect(isClientDenied('cursor-vscode')).toBe(false);
+	});
+
+	it('env var can drop cursor and target only another client', () => {
+		process.env[ENV] = 'only-this';
+		expect(isClientDenied('cursor-vscode')).toBe(false);
+		expect(isClientDenied('only-this')).toBe(true);
+	});
+});


### PR DESCRIPTION
## Problem

The Skills deploy triggered a self-inflicted request flood — ~**100k req/min vs ~3.5k baseline** — and the server was switched off. Metrics showed **~76,673 `resources/subscribe` calls in ~9 minutes, ~99.7% from `cursor-vscode`** (the rest `cursor-vscode (via mcp-remote 0.1.37)`). Cursor retry-loops `resources/subscribe` against the skill resources.

## What I found

- The server **never advertised `subscribe`** — capabilities are `resources: { listChanged: false }` (verified live). Cursor subscribes anyway, ignoring the absent capability. So advertising `subscribe: false` alone won't stop it.
- `resources/subscribe` already routed to the cheap stub responder, so per-request cost was low — the problem is pure **volume**.

## Changes

Both of @evalstate's suggestions, with the denylist as the functional fix:

1. **Client denylist (`shared/client-denylist.ts`)** — default `['cursor-vscode']`, overridable via `MCP_RESOURCES_CLIENT_DENYLIST` (comma-separated; set empty to disable). Matched case-insensitively as a **substring** against both the MCP `clientInfo.name` and the HTTP `user-agent`. Denied clients are offered **no resources**:
   - `mcp-server.ts` skips `registerSkillResources` and advertises no `resources` capability / skills extension.
   - `stateless-http-transport.ts` `shouldHandle()` routes their `resources/list|read` to the stub responder.
2. **Explicit `subscribe: false`** in the advertised `resources` capability, plus a cheap `-32601` method-not-found short-circuit for `resources/subscribe|unsubscribe` **before any server is built**. We never supported subscriptions (skills are static — nothing to notify `resources/updated` about), so rejecting is spec-correct.

## Config

- `MCP_RESOURCES_CLIENT_DENYLIST=cursor-vscode` (default if unset). Set `MCP_RESOURCES_CLIENT_DENYLIST=` (empty) to disable, or `cursor-vscode,other` to extend.

## Verification

- Unit tests: denylist matching (name + UA, substring, case-insensitive, env replace/extend/empty-disable) and capability gating (subscribe:false present; no resources/extensions when denied). Full suite green (273 app tests; the 2 paper-search failures are pre-existing TZ-only and pass under UTC/CI).
- Live local probe (stateless JSON transport, real distribution index): `cursor-vscode` initialize → no `resources`/`extensions`; normal client → `resources: { subscribe: false, listChanged: false }` + skills extension; `resources/subscribe` → `-32601`; `resources/list` with UA `cursor-vscode` → denied (stub); normal list → 16 resources.

## Note

The server never actually advertised `subscribe`, so `subscribe: false` is explicit-but-secondary; the **denylist is what stops the flood**. Default-denying `cursor-vscode` disables Skills for cursor clients until Cursor stops the subscribe loop — flip via the env var.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
