### PR TITLE
fix(app): attribute resource subscribe metrics by client

### DIFF
--- a/packages/app/src/server/transport/stateless-http-transport.ts
+++ b/packages/app/src/server/transport/stateless-http-transport.ts
@@ -266,10 +266,15 @@ export class StatelessHttpTransport extends BaseTransport {
 		// cheaply before building any server — cursor-vscode floods `resources/subscribe`.
 		const rpcMethod = requestBody?.method;
 		if (rpcMethod && UNSUPPORTED_SUBSCRIBE_METHODS.has(rpcMethod)) {
-			this.trackMethodCall(trackingName, startTime, false);
-			res.status(200).json(
-				JsonRpcErrors.methodNotFound(extractJsonRpcId(req.body), `${rpcMethod} is not supported`)
-			);
+			const earlySessionId = headers['mcp-session-id'];
+			const earlyClientInfo =
+				this.extractClientInfoFromRequest(requestBody) ??
+				(typeof earlySessionId === 'string'
+					? this.analyticsSessions.get(earlySessionId)?.metadata.clientInfo
+					: undefined);
+
+			this.trackMethodCall(trackingName, startTime, false, earlyClientInfo);
+			res.status(200).json(JsonRpcErrors.methodNotFound(extractJsonRpcId(req.body), `${rpcMethod} is not supported`));
 			return;
 		}
 
@@ -315,7 +320,7 @@ export class StatelessHttpTransport extends BaseTransport {
 					// Log details if temp logging is active
 					if (this.tempLogCounter > 0) {
 						const logNumber = this.tempLogOriginalCount - this.tempLogCounter + 1;
-						
+
 						// Redact HF token if present - show only last 5 chars
 						let hfTokenInfo: string | undefined;
 						const hfToken = headers['authorization'] || headers['hf-token'] || headers['x-hf-token'];
@@ -327,7 +332,7 @@ export class StatelessHttpTransport extends BaseTransport {
 								hfTokenInfo = '[PRESENT BUT TOO SHORT]';
 							}
 						}
-						
+
 						console.log(`[TEMPLOG ${logNumber}/${this.tempLogOriginalCount}] Session Resume Failed:`, {
 							sessionId: sessionId,
 							timestamp: new Date().toISOString(),

--- a/packages/app/test/server/transport/stateless-http-transport.test.ts
+++ b/packages/app/test/server/transport/stateless-http-transport.test.ts
@@ -1,17 +1,31 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { StatelessHttpTransport } from '../../../src/server/transport/stateless-http-transport.js';
 import type { ServerFactory } from '../../../src/server/transport/base-transport.js';
 import express from 'express';
 
 describe('StatelessHttpTransport', () => {
 	let transport: StatelessHttpTransport;
+	const originalAnalyticsMode = process.env.ANALYTICS_MODE;
 
 	beforeEach(() => {
+		if (originalAnalyticsMode === undefined) {
+			delete process.env.ANALYTICS_MODE;
+		} else {
+			process.env.ANALYTICS_MODE = originalAnalyticsMode;
+		}
 		// Create a minimal instance for testing private methods
 		const mockServerFactory = vi.fn() as unknown as ServerFactory;
 		const mockApp = express();
 		transport = new StatelessHttpTransport(mockServerFactory, mockApp);
+	});
+
+	afterEach(() => {
+		if (originalAnalyticsMode === undefined) {
+			delete process.env.ANALYTICS_MODE;
+		} else {
+			process.env.ANALYTICS_MODE = originalAnalyticsMode;
+		}
 	});
 
 	describe('shouldHandle', () => {
@@ -126,6 +140,43 @@ describe('StatelessHttpTransport', () => {
 			});
 
 			expect(result).toBe(true);
+		});
+	});
+
+	describe('unsupported resource subscriptions', () => {
+		it('attributes early resources/subscribe rejections to known analytics session client info', async () => {
+			process.env.ANALYTICS_MODE = 'true';
+			const mockServerFactory = vi.fn() as unknown as ServerFactory;
+			transport = new StatelessHttpTransport(mockServerFactory, express());
+
+			const sessionId = 'session-1';
+			const clientInfo = { name: 'cursor-vscode', version: '1.2.3' };
+			(transport as any).createAnalyticsSession(sessionId, false, '127.0.0.1');
+			(transport as any).updateAnalyticsSessionClientInfo(sessionId, clientInfo);
+
+			const req = {
+				headers: { 'mcp-session-id': sessionId },
+				query: {},
+				body: {
+					jsonrpc: '2.0',
+					id: 1,
+					method: 'resources/subscribe',
+					params: { uri: 'skill://example/SKILL.md' },
+				},
+				ip: '127.0.0.1',
+			};
+			const res = {
+				status: vi.fn().mockReturnThis(),
+				json: vi.fn().mockReturnThis(),
+			};
+
+			await (transport as any).handleJsonRpcRequest(req, res);
+
+			const methodMetrics = transport.getMetrics().methods.get('resources/subscribe');
+			expect(methodMetrics?.count).toBe(1);
+			expect(methodMetrics?.byClient.get(clientInfo.name)?.count).toBe(1);
+			expect(mockServerFactory).not.toHaveBeenCalled();
+			expect(res.status).toHaveBeenCalledWith(200);
 		});
 	});
 });


### PR DESCRIPTION
## Summary
- resolve known analytics-session client info before fast-failing unsupported resource subscription methods
- pass that client info into method metrics so resources/subscribe populates byClient
- add a regression test covering early resources/subscribe rejection attribution

## Tests
- pnpm -C packages/app typecheck
- pnpm -C packages/app test -- test/server/transport/stateless-http-transport.test.ts
- pnpm -C packages/app exec prettier --check src/server/transport/stateless-http-transport.ts test/server/transport/stateless-http-transport.test.ts