### PR TITLE
fix(app): include resource URI in subscribe metrics

### DIFF
--- a/packages/app/src/server/transport/base-transport.ts
+++ b/packages/app/src/server/transport/base-transport.ts
@@ -244,7 +244,7 @@ export abstract class BaseTransport {
 	 */
 	protected extractMethodForTracking(requestBody: unknown): string | null {
 		const body = requestBody as
-			| { method?: string; params?: { name?: string }; id?: unknown; result?: unknown; error?: unknown }
+			| { method?: string; params?: { name?: string; uri?: unknown }; id?: unknown; result?: unknown; error?: unknown }
 			| undefined;
 
 		// If this is a JSON-RPC response (has id and result/error but no method), don't track it
@@ -272,11 +272,18 @@ export abstract class BaseTransport {
 			}
 		}
 
-		// For resources/read, extract the resource URI as well.
-		if (methodName === 'resources/read' && body?.params && typeof body.params === 'object' && 'uri' in body.params) {
+		// For resource URI methods, extract the resource URI as well.
+		if (
+			(methodName === 'resources/read' ||
+				methodName === 'resources/subscribe' ||
+				methodName === 'resources/unsubscribe') &&
+			body?.params &&
+			typeof body.params === 'object' &&
+			'uri' in body.params
+		) {
 			const resourceUri = body.params.uri;
 			if (typeof resourceUri === 'string') {
-				return `resources/read:${resourceUri}`;
+				return `${methodName}:${resourceUri}`;
 			}
 		}
 

--- a/packages/app/src/shared/transport-metrics.ts
+++ b/packages/app/src/shared/transport-metrics.ts
@@ -145,6 +145,9 @@ export interface GradioCacheMetrics {
 	overallHitRate: number; // percentage
 }
 
+const MAX_DISTINCT_METHOD_DETAILS = 500;
+const UNEXPECTED_METHOD_DETAIL = '__unexpected__';
+
 /**
  * API response format for transport metrics
  */
@@ -434,6 +437,7 @@ export class MetricsCounter {
 	private uniqueIps: Set<string>;
 	private clientIps: Map<string, Set<string>>; // Map of clientKey -> Set of IPs
 	private clientAuthHashes: Map<string, Set<string>>; // Map of clientKey -> Set of auth token hashes
+	private methodDetailsByBaseMethod: Map<string, Set<string>>;
 
 	constructor() {
 		this.metrics = createEmptyMetrics();
@@ -443,6 +447,7 @@ export class MetricsCounter {
 		this.uniqueIps = new Set();
 		this.clientIps = new Map();
 		this.clientAuthHashes = new Map();
+		this.methodDetailsByBaseMethod = new Map();
 	}
 
 	/**
@@ -681,6 +686,7 @@ export class MetricsCounter {
 		clientInfo?: { name: string; version: string }
 	): void {
 		if (!method) return;
+		method = this.normalizeMethodName(method);
 		let methodMetrics = this.metrics.methods.get(method);
 
 		if (!methodMetrics) {
@@ -738,6 +744,27 @@ export class MetricsCounter {
 				methodMetrics.averageResponseTime = totalTime / successfulCalls;
 			}
 		}
+	}
+
+	private normalizeMethodName(method: string): string {
+		const detailSeparator = method.indexOf(':');
+		if (detailSeparator === -1) return method;
+
+		const baseMethod = method.slice(0, detailSeparator);
+		const detail = method.slice(detailSeparator + 1);
+		let knownDetails = this.methodDetailsByBaseMethod.get(baseMethod);
+		if (!knownDetails) {
+			knownDetails = new Set();
+			this.methodDetailsByBaseMethod.set(baseMethod, knownDetails);
+		}
+
+		if (knownDetails.has(detail)) return method;
+		if (knownDetails.size < MAX_DISTINCT_METHOD_DETAILS) {
+			knownDetails.add(detail);
+			return method;
+		}
+
+		return `${baseMethod}:${UNEXPECTED_METHOD_DETAIL}`;
 	}
 
 	/**

--- a/packages/app/test/server/transport/stateless-http-transport.test.ts
+++ b/packages/app/test/server/transport/stateless-http-transport.test.ts
@@ -144,7 +144,14 @@ describe('StatelessHttpTransport', () => {
 	});
 
 	describe('unsupported resource subscriptions', () => {
-		it('includes subscribe and unsubscribe resource URIs in tracked method names', () => {
+		it('includes resource URIs in tracked method names', () => {
+			expect(
+				(transport as any).extractMethodForTracking({
+					method: 'resources/read',
+					params: { uri: 'skill://example/SKILL.md' },
+				})
+			).toBe('resources/read:skill://example/SKILL.md');
+
 			expect(
 				(transport as any).extractMethodForTracking({
 					method: 'resources/subscribe',

--- a/packages/app/test/server/transport/stateless-http-transport.test.ts
+++ b/packages/app/test/server/transport/stateless-http-transport.test.ts
@@ -144,6 +144,22 @@ describe('StatelessHttpTransport', () => {
 	});
 
 	describe('unsupported resource subscriptions', () => {
+		it('includes subscribe and unsubscribe resource URIs in tracked method names', () => {
+			expect(
+				(transport as any).extractMethodForTracking({
+					method: 'resources/subscribe',
+					params: { uri: 'skill://example/SKILL.md' },
+				})
+			).toBe('resources/subscribe:skill://example/SKILL.md');
+
+			expect(
+				(transport as any).extractMethodForTracking({
+					method: 'resources/unsubscribe',
+					params: { uri: 'skill://example/SKILL.md' },
+				})
+			).toBe('resources/unsubscribe:skill://example/SKILL.md');
+		});
+
 		it('attributes early resources/subscribe rejections to known analytics session client info', async () => {
 			process.env.ANALYTICS_MODE = 'true';
 			const mockServerFactory = vi.fn() as unknown as ServerFactory;
@@ -172,7 +188,7 @@ describe('StatelessHttpTransport', () => {
 
 			await (transport as any).handleJsonRpcRequest(req, res);
 
-			const methodMetrics = transport.getMetrics().methods.get('resources/subscribe');
+			const methodMetrics = transport.getMetrics().methods.get('resources/subscribe:skill://example/SKILL.md');
 			expect(methodMetrics?.count).toBe(1);
 			expect(methodMetrics?.byClient.get(clientInfo.name)?.count).toBe(1);
 			expect(mockServerFactory).not.toHaveBeenCalled();

--- a/packages/app/test/shared/transport-metrics.test.ts
+++ b/packages/app/test/shared/transport-metrics.test.ts
@@ -1,10 +1,45 @@
 import { describe, it, expect } from 'vitest';
-import { isInitializeRequest } from '../../src/shared/transport-metrics.js';
+import { MetricsCounter, isInitializeRequest } from '../../src/shared/transport-metrics.js';
 
 describe('isInitializeRequest', () => {
 	it('should identify initialize requests', () => {
 		expect(isInitializeRequest('initialize')).toBe(true);
 		expect(isInitializeRequest('notifications/initialized')).toBe(false);
 		expect(isInitializeRequest('tools/list')).toBe(false);
+	});
+});
+
+describe('MetricsCounter', () => {
+	it('buckets method details after too many distinct values for a base method', () => {
+		const metrics = new MetricsCounter();
+
+		for (let i = 0; i < 500; i++) {
+			metrics.trackMethod(`resources/subscribe:skill://example/${i}`);
+		}
+
+		metrics.trackMethod('resources/subscribe:skill://example/500');
+		metrics.trackMethod('resources/subscribe:skill://example/501');
+		metrics.trackMethod('resources/read:skill://example/0');
+
+		const methodMetrics = metrics.getMetrics().methods;
+		expect(methodMetrics.size).toBe(502);
+		expect(methodMetrics.get('resources/subscribe:skill://example/0')?.count).toBe(1);
+		expect(methodMetrics.get('resources/subscribe:__unexpected__')?.count).toBe(2);
+		expect(methodMetrics.get('resources/read:skill://example/0')?.count).toBe(1);
+	});
+
+	it('continues tracking previously seen method details after the bucket is full', () => {
+		const metrics = new MetricsCounter();
+
+		for (let i = 0; i < 500; i++) {
+			metrics.trackMethod(`tools/call:tool_${i}`);
+		}
+
+		metrics.trackMethod('tools/call:tool_42');
+		metrics.trackMethod('tools/call:tool_500');
+
+		const methodMetrics = metrics.getMetrics().methods;
+		expect(methodMetrics.get('tools/call:tool_42')?.count).toBe(2);
+		expect(methodMetrics.get('tools/call:__unexpected__')?.count).toBe(1);
 	});
 });


### PR DESCRIPTION
## Summary
- include resource URIs in method metric names for resources/subscribe and resources/unsubscribe
- preserve existing resources/read URI metric behavior via shared URI-method handling
- update subscribe attribution regression coverage to assert the URI-qualified metric key

## Tests
- pnpm -C packages/app typecheck
- pnpm -C packages/app test -- test/server/transport/stateless-http-transport.test.ts
- pnpm -C packages/app exec prettier --check src/server/transport/base-transport.ts test/server/transport/stateless-http-transport.test.ts