### PR TITLE
feat(skills): align Skills extension with latest SEP-2640

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ The server respects the following environment variables:
 - `SEARCH_ENABLES_FETCH`: When set to `true`, automatically enables the `hf_doc_fetch` tool whenever `hf_doc_search` is enabled
 - `PROXY_TOOLS_CSV`: Optional CSV that defines Streamable HTTP proxy tool sources (see below).
 - `GRADIO_SKIP_INITIALIZE`: When set to `true`, Gradio MCP calls skip the `initialize` handshake and issue `tools/call` directly.
-- `HF_SKILLS_DIR`: Local directory containing a prebuilt Agent Skills distribution (`index.json` plus referenced `SKILL.md` and `.tar.gz` files). Defaults to `/mnt/hf-skills/distribution/latest`, which is intended for a Hugging Face Space volume mounted from `hf://buckets/huggingface/skills`.
+- `HF_SKILLS_DIR`: Local directory containing a prebuilt skills distribution in the [SEP-2640](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2640) index format (a `skill://index.json` whose entries carry verbatim `frontmatter`, an optional `url` + `digest`, and an `archives[]` array, alongside the expanded `SKILL.md`/supporting-file tree and `.tar.gz` archives). The server walks each skill directory and exposes every file as an individual `skill://` resource, supports `resources/directory/read` for scoped navigation, and advertises the `io.modelcontextprotocol/skills` extension with `directoryRead: true`. Defaults to `/mnt/hf-skills/distribution/latest`, intended for a Hugging Face Space volume mounted from `hf://buckets/huggingface/skills`.
 
 To expose the shared Hugging Face skills catalog from a Space, mount the bucket and keep `HF_SKILLS_DIR` pointed at its latest distribution directory:
 

--- a/packages/app/src/server/mcp-server.ts
+++ b/packages/app/src/server/mcp-server.ts
@@ -209,7 +209,7 @@ export const createServerFactory = (_webServerInstance: WebServer, sharedApiClie
 		// Some clients (e.g. cursor-vscode) flood the resource surface; deny them the
 		// Skills resources entirely — not registered and not advertised.
 		const clientDenied = isClientDenied(sessionInfo?.clientInfo?.name, headers?.['user-agent']);
-		const hasSkills = !!skillCatalog?.skills.length && !clientDenied;
+		const hasSkills = !!skillCatalog?.entries.length && !clientDenied;
 
 		/**
 		 *  we will set capabilities below. use of the convenience .tool() registration methods automatically

--- a/packages/app/src/server/skills/skill-directory-schema.ts
+++ b/packages/app/src/server/skills/skill-directory-schema.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+
+// `resources/directory/read` (SEP-2640, WG decision 2026-06-09). The MCP SDK at ^1.29.0
+// has no built-in schema for this extension method, so we define the request shape locally
+// and register it via `server.server.setRequestHandler`. The result reuses the
+// `resources/list` shape (an array of Resource + optional `nextCursor`).
+export const RESOURCES_DIRECTORY_READ_METHOD = 'resources/directory/read';
+
+export const ResourcesDirectoryReadRequestSchema = z
+	.object({
+		method: z.literal(RESOURCES_DIRECTORY_READ_METHOD),
+		params: z
+			.object({
+				uri: z.string(),
+				cursor: z.string().optional(),
+			})
+			.passthrough(),
+	})
+	.passthrough();

--- a/packages/app/src/server/skills/skill-loader.ts
+++ b/packages/app/src/server/skills/skill-loader.ts
@@ -1,16 +1,33 @@
 import fs from 'node:fs/promises';
+import type { Dirent } from 'node:fs';
 import path from 'node:path';
 import { logger } from '../utils/logger.js';
-import { mimeFor } from './skill-uri.js';
-import type { SkillCatalog, SkillResource, SkillResourceType } from './skill-types.js';
+import { buildSkillDirUri, buildSkillUri, DIRECTORY_MIME, mimeFor } from './skill-uri.js';
+import type {
+	ReadableSkillFile,
+	SkillArchive,
+	SkillCatalog,
+	SkillDirChild,
+	SkillEntry,
+	SkillFrontmatter,
+	SkillResource,
+} from './skill-types.js';
 
 const INDEX_FILE = 'index.json';
+const SKILL_MD = 'SKILL.md';
 
+// New-format index entry (SEP-2640, WG decision 2026-06-05): verbatim `frontmatter`,
+// optional `url` + `digest`, and a per-skill `archives[]` array.
 interface IndexEntry {
-	name: unknown;
-	type: unknown;
-	description: unknown;
-	url: unknown;
+	frontmatter?: unknown;
+	url?: unknown;
+	digest?: unknown;
+	archives?: unknown;
+}
+
+interface ArchiveEntry {
+	url?: unknown;
+	mimeType?: unknown;
 	digest?: unknown;
 }
 
@@ -19,13 +36,17 @@ interface IndexJson {
 }
 
 function emptyCatalog(indexPath: string, indexText = ''): SkillCatalog {
-	return { indexPath, indexText, skills: [], compatibilityFiles: [] };
+	return { indexPath, indexText, entries: [], resourcesByUri: new Map(), directories: new Map() };
 }
 
-function isSkillResourceType(value: unknown): value is SkillResourceType {
-	return value === 'skill-md' || value === 'archive';
+function parseFrontmatter(value: unknown): SkillFrontmatter | null {
+	if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+	const fm = value as Record<string, unknown>;
+	if (typeof fm.name !== 'string' || typeof fm.description !== 'string') return null;
+	return fm as SkillFrontmatter;
 }
 
+/** Resolve a `skill://` URL to an on-disk path, rejecting traversal outside `rootDir`. */
 function resolveSkillUrl(rootDir: string, url: string): { absPath: string; relPath: string } | null {
 	const prefix = 'skill://';
 	if (!url.startsWith(prefix) || url.includes('?') || url.includes('#')) {
@@ -56,46 +77,155 @@ function resolveSkillUrl(rootDir: string, url: string): { absPath: string; relPa
 	return { absPath, relPath: parts.join('/') };
 }
 
-async function loadIndexEntry(rootDir: string, entry: IndexEntry): Promise<SkillResource | null> {
-	if (
-		typeof entry.name !== 'string' ||
-		!isSkillResourceType(entry.type) ||
-		typeof entry.description !== 'string' ||
-		typeof entry.url !== 'string'
-	) {
-		logger.warn({ entry }, 'invalid skill index entry, skipping');
-		return null;
-	}
-
-	const resolved = resolveSkillUrl(rootDir, entry.url);
-	if (!resolved) {
-		logger.warn({ url: entry.url }, 'invalid skill resource URL, skipping');
-		return null;
-	}
-
+async function isRegularFile(absPath: string): Promise<boolean> {
 	try {
-		const stat = await fs.lstat(resolved.absPath);
-		if (!stat.isFile() || stat.isSymbolicLink()) {
-			logger.warn({ path: resolved.absPath }, 'skill resource is not a regular file, skipping');
+		const stat = await fs.lstat(absPath);
+		return stat.isFile() && !stat.isSymbolicLink();
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Recursively walk a skill directory, collecting individually-addressable file resources
+ * and recording each directory's direct children for `resources/directory/read`.
+ * Symlinks are skipped (matching the resolve-time guard) so a skill cannot point outside
+ * its own directory.
+ */
+async function walkSkillDir(
+	skillPath: string,
+	absDir: string,
+	relDir: string,
+	frontmatter: SkillFrontmatter,
+	files: SkillResource[],
+	directories: Map<string, SkillDirChild[]>,
+): Promise<void> {
+	const dirUri = buildSkillDirUri(skillPath, relDir);
+	const children: SkillDirChild[] = [];
+
+	let dirents: Dirent[];
+	try {
+		dirents = await fs.readdir(absDir, { withFileTypes: true });
+	} catch (err) {
+		logger.warn({ absDir, err }, 'failed to read skill directory, skipping contents');
+		directories.set(dirUri, children);
+		return;
+	}
+
+	dirents.sort((a, b) => a.name.localeCompare(b.name));
+
+	for (const dirent of dirents) {
+		if (dirent.isSymbolicLink()) {
+			logger.warn({ dir: absDir, name: dirent.name }, 'skipping symlink in skill directory');
+			continue;
+		}
+		const childRel = relDir ? `${relDir}/${dirent.name}` : dirent.name;
+		if (dirent.isDirectory()) {
+			children.push({ uri: buildSkillDirUri(skillPath, childRel), name: dirent.name, mimeType: DIRECTORY_MIME });
+			await walkSkillDir(skillPath, path.join(absDir, dirent.name), childRel, frontmatter, files, directories);
+		} else if (dirent.isFile()) {
+			const url = buildSkillUri(skillPath, childRel);
+			const { mimeType, isText } = mimeFor(childRel);
+			const isSkillMd = childRel === SKILL_MD;
+			files.push({
+				url,
+				absPath: path.join(absDir, dirent.name),
+				mimeType,
+				isText,
+				name: isSkillMd ? frontmatter.name : dirent.name,
+				description: isSkillMd ? frontmatter.description : undefined,
+			});
+			children.push({ uri: url, name: dirent.name, mimeType });
+		}
+	}
+
+	directories.set(dirUri, children);
+}
+
+async function loadArchives(rootDir: string, raw: unknown): Promise<SkillArchive[]> {
+	if (!Array.isArray(raw)) return [];
+	const archives: SkillArchive[] = [];
+	for (const item of raw as ArchiveEntry[]) {
+		if (typeof item?.url !== 'string' || typeof item?.mimeType !== 'string') {
+			logger.warn({ archive: item }, 'invalid archive entry, skipping');
+			continue;
+		}
+		const resolved = resolveSkillUrl(rootDir, item.url);
+		if (!resolved || !(await isRegularFile(resolved.absPath))) {
+			logger.warn({ url: item.url }, 'archive resource missing or invalid, skipping');
+			continue;
+		}
+		archives.push({
+			url: item.url,
+			absPath: resolved.absPath,
+			mimeType: item.mimeType,
+			isText: false,
+			name: path.basename(resolved.relPath),
+			digest: typeof item.digest === 'string' ? item.digest : undefined,
+		});
+	}
+	return archives;
+}
+
+async function loadIndexEntry(
+	rootDir: string,
+	entry: IndexEntry,
+	directories: Map<string, SkillDirChild[]>,
+): Promise<SkillEntry | null> {
+	const frontmatter = parseFrontmatter(entry.frontmatter);
+	if (!frontmatter) {
+		logger.warn({ entry }, 'skill index entry missing valid frontmatter (name/description), skipping');
+		return null;
+	}
+
+	const hasUrl = typeof entry.url === 'string';
+	const archives = await loadArchives(rootDir, entry.archives);
+
+	if (!hasUrl && archives.length === 0) {
+		logger.warn({ name: frontmatter.name }, 'skill index entry has neither a readable url nor archives, skipping');
+		return null;
+	}
+
+	let skillMd: SkillEntry['skillMd'];
+	let skillPath = frontmatter.name;
+	const files: SkillResource[] = [];
+
+	if (hasUrl) {
+		const url = entry.url as string;
+		const resolved = resolveSkillUrl(rootDir, url);
+		if (!resolved) {
+			logger.warn({ url }, 'invalid skill resource URL, skipping entry');
 			return null;
 		}
-	} catch (err) {
-		logger.warn({ path: resolved.absPath, err }, 'skill resource missing, skipping');
-		return null;
+		const parts = resolved.relPath.split('/');
+		if (parts.length < 2 || parts[parts.length - 1] !== SKILL_MD) {
+			logger.warn({ url }, 'skill url must point to a SKILL.md, skipping entry');
+			return null;
+		}
+		skillPath = parts.slice(0, -1).join('/');
+		const finalSegment = parts[parts.length - 2];
+		if (finalSegment !== frontmatter.name) {
+			logger.warn(
+				{ url, finalSegment, name: frontmatter.name },
+				'final skill-path segment must equal frontmatter.name, skipping entry',
+			);
+			return null;
+		}
+		if (!(await isRegularFile(resolved.absPath))) {
+			logger.warn({ path: resolved.absPath }, 'SKILL.md missing or not a regular file, skipping entry');
+			return null;
+		}
+		if (typeof entry.digest !== 'string') {
+			logger.warn({ url }, 'skill entry with url is missing a digest (recommended by SEP-2640)');
+		}
+
+		const absDir = path.dirname(resolved.absPath);
+		await walkSkillDir(skillPath, absDir, '', frontmatter, files, directories);
+
+		skillMd = { url, digest: typeof entry.digest === 'string' ? entry.digest : undefined };
 	}
 
-	const { mimeType, isText } = mimeFor(resolved.relPath);
-
-	return {
-		name: entry.name,
-		type: entry.type,
-		description: entry.description,
-		url: entry.url,
-		digest: typeof entry.digest === 'string' ? entry.digest : undefined,
-		absPath: resolved.absPath,
-		mimeType,
-		isText,
-	};
+	return { skillPath, frontmatter, skillMd, files, archives };
 }
 
 export async function loadSkills(rootDir: string): Promise<SkillCatalog> {
@@ -121,19 +251,31 @@ export async function loadSkills(rootDir: string): Promise<SkillCatalog> {
 		return emptyCatalog(indexPath, indexText);
 	}
 
-	const skills: SkillResource[] = [];
-	const seenUrls = new Set<string>();
-	for (const entry of parsed.skills as IndexEntry[]) {
-		const skill = await loadIndexEntry(rootDir, entry);
-		if (!skill) continue;
-		if (seenUrls.has(skill.url)) {
-			logger.warn({ url: skill.url }, 'duplicate skill resource URL, skipping');
-			continue;
+	const entries: SkillEntry[] = [];
+	const resourcesByUri = new Map<string, ReadableSkillFile>();
+	const directories = new Map<string, SkillDirChild[]>();
+
+	for (const raw of parsed.skills as IndexEntry[]) {
+		const entry = await loadIndexEntry(rootDir, raw, directories);
+		if (!entry) continue;
+
+		const readables: ReadableSkillFile[] = [...entry.files, ...entry.archives];
+		let conflict = false;
+		for (const file of readables) {
+			if (resourcesByUri.has(file.url)) {
+				logger.warn({ url: file.url }, 'duplicate skill resource URL, skipping entry');
+				conflict = true;
+				break;
+			}
 		}
-		seenUrls.add(skill.url);
-		skills.push(skill);
+		if (conflict) continue;
+
+		for (const file of readables) {
+			resourcesByUri.set(file.url, file);
+		}
+		entries.push(entry);
 	}
 
-	logger.info({ rootDir, count: skills.length }, 'loaded skills');
-	return { indexPath, indexText, skills, compatibilityFiles: [] };
+	logger.info({ rootDir, skills: entries.length, resources: resourcesByUri.size }, 'loaded skills');
+	return { indexPath, indexText, entries, resourcesByUri, directories };
 }

--- a/packages/app/src/server/skills/skill-resource-data.ts
+++ b/packages/app/src/server/skills/skill-resource-data.ts
@@ -1,7 +1,11 @@
 import fs from 'node:fs/promises';
-import type { SkillCatalog, SkillResource } from './skill-types.js';
+import type { ReadableSkillFile, SkillCatalog } from './skill-types.js';
 
 export const SKILL_INDEX_URI = 'skill://index.json';
+
+// Default page size for `resources/directory/read`. Skill directories are small, so this
+// is effectively a single page in practice; pagination is implemented for spec conformance.
+const DIR_PAGE_SIZE = 500;
 
 export interface ListedSkillResource {
 	uri: string;
@@ -19,25 +23,31 @@ export type SkillResourceContent =
 	| (BaseSkillResourceContent & { text: string })
 	| (BaseSkillResourceContent & { blob: string });
 
-export function skillResourceName(skill: SkillResource): string {
-	return skill.type === 'archive' ? `${skill.name}.tar.gz` : skill.name;
+export interface SkillDirectoryListing {
+	resources: { uri: string; name: string; mimeType: string }[];
+	nextCursor?: string;
 }
 
+/** All readable file resources (skill files + archives) plus the index. Directories are
+ * intentionally omitted — they are addressable via `resources/directory/read` but need not
+ * appear in `resources/list`. */
 export function listSkillResources(catalog: SkillCatalog): ListedSkillResource[] {
-	return [
-		...catalog.skills.map((skill) => ({
-			uri: skill.url,
-			name: skillResourceName(skill),
-			description: skill.description,
-			mimeType: skill.mimeType,
-		})),
-		{
-			uri: SKILL_INDEX_URI,
-			name: 'Skills Index',
-			description: 'Catalog of skills exposed by this server (Agent Skills discovery schema).',
-			mimeType: 'application/json',
-		},
-	];
+	const resources: ListedSkillResource[] = [];
+	for (const entry of catalog.entries) {
+		for (const file of entry.files) {
+			resources.push({ uri: file.url, name: file.name, description: file.description, mimeType: file.mimeType });
+		}
+		for (const archive of entry.archives) {
+			resources.push({ uri: archive.url, name: archive.name, mimeType: archive.mimeType });
+		}
+	}
+	resources.push({
+		uri: SKILL_INDEX_URI,
+		name: 'Skills Index',
+		description: 'Catalog of skills exposed by this server (SEP-2640 index).',
+		mimeType: 'application/json',
+	});
+	return resources;
 }
 
 export async function readSkillResource(catalog: SkillCatalog, uri: string): Promise<SkillResourceContent | null> {
@@ -45,15 +55,52 @@ export async function readSkillResource(catalog: SkillCatalog, uri: string): Pro
 		return { uri, mimeType: 'application/json', text: catalog.indexText };
 	}
 
-	const skill = catalog.skills.find((candidate) => candidate.url === uri);
-	if (!skill) return null;
+	const file = catalog.resourcesByUri.get(uri);
+	if (!file) return null;
 
-	return readSkillFile(skill);
+	return readSkillFile(file);
 }
 
-export async function readSkillFile(skill: SkillResource): Promise<SkillResourceContent> {
-	const buf = await fs.readFile(skill.absPath);
-	return skill.isText
-		? { uri: skill.url, mimeType: skill.mimeType, text: buf.toString('utf8') }
-		: { uri: skill.url, mimeType: skill.mimeType, blob: buf.toString('base64') };
+export async function readSkillFile(file: ReadableSkillFile): Promise<SkillResourceContent> {
+	const buf = await fs.readFile(file.absPath);
+	return file.isText
+		? { uri: file.url, mimeType: file.mimeType, text: buf.toString('utf8') }
+		: { uri: file.url, mimeType: file.mimeType, blob: buf.toString('base64') };
+}
+
+function decodeCursor(cursor: string | undefined): number | null {
+	if (cursor === undefined) return 0;
+	const offset = Number.parseInt(cursor, 10);
+	if (!Number.isInteger(offset) || offset < 0) return null;
+	return offset;
+}
+
+/**
+ * List the direct children of a directory resource (`resources/directory/read`). Returns
+ * `null` when the URI is not a known directory (caller maps that to JSON-RPC -32602).
+ * `cursor` is an opaque offset following the `resources/list` pagination contract.
+ */
+export function readSkillDirectory(
+	catalog: SkillCatalog,
+	uri: string,
+	cursor?: string,
+	pageSize: number = DIR_PAGE_SIZE,
+): SkillDirectoryListing | null {
+	// Normalise away a trailing slash; directory URIs are stored without one.
+	const normalised = uri.endsWith('/') ? uri.slice(0, -1) : uri;
+	const children = catalog.directories.get(normalised);
+	if (!children) return null;
+
+	const offset = decodeCursor(cursor);
+	if (offset === null) return null;
+
+	const page = children.slice(offset, offset + pageSize);
+	const nextOffset = offset + page.length;
+	const listing: SkillDirectoryListing = {
+		resources: page.map((child) => ({ uri: child.uri, name: child.name, mimeType: child.mimeType })),
+	};
+	if (nextOffset < children.length) {
+		listing.nextCursor = String(nextOffset);
+	}
+	return listing;
 }

--- a/packages/app/src/server/skills/skill-resources.ts
+++ b/packages/app/src/server/skills/skill-resources.ts
@@ -1,33 +1,37 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { ErrorCode, McpError, type ServerResult } from '@modelcontextprotocol/sdk/types.js';
 import { logger } from '../utils/logger.js';
-import type { SkillCatalog, SkillResource } from './skill-types.js';
-import { listSkillResources, readSkillFile, skillResourceName, SKILL_INDEX_URI } from './skill-resource-data.js';
+import type { ReadableSkillFile, SkillCatalog } from './skill-types.js';
+import { listSkillResources, readSkillDirectory, readSkillFile, SKILL_INDEX_URI } from './skill-resource-data.js';
+import { ResourcesDirectoryReadRequestSchema } from './skill-directory-schema.js';
 
-function registerSkillResource(server: McpServer, skill: SkillResource): void {
+function registerReadable(server: McpServer, name: string, file: ReadableSkillFile, description?: string): void {
 	server.registerResource(
-		skillResourceName(skill),
-		skill.url,
-		{
-			description: skill.description,
-			mimeType: skill.mimeType,
-		},
+		name,
+		file.url,
+		description ? { description, mimeType: file.mimeType } : { mimeType: file.mimeType },
 		async () => {
-			const content = await readSkillFile(skill);
+			const content = await readSkillFile(file);
 			return { contents: [content] };
 		},
 	);
 }
 
 export function registerSkillResources(server: McpServer, catalog: SkillCatalog): void {
-	for (const skill of catalog.skills) {
-		registerSkillResource(server, skill);
+	for (const entry of catalog.entries) {
+		for (const file of entry.files) {
+			registerReadable(server, file.name, file, file.description);
+		}
+		for (const archive of entry.archives) {
+			registerReadable(server, archive.name, archive);
+		}
 	}
 
 	server.registerResource(
 		'Skills Index',
 		SKILL_INDEX_URI,
 		{
-			description: 'Catalog of skills exposed by this server (Agent Skills discovery schema).',
+			description: 'Catalog of skills exposed by this server (SEP-2640 index).',
 			mimeType: 'application/json',
 		},
 		async () => ({
@@ -35,6 +39,16 @@ export function registerSkillResources(server: McpServer, catalog: SkillCatalog)
 		}),
 	);
 
+	// SEP-2640 `resources/directory/read`: list the direct children of a directory resource.
+	server.server.setRequestHandler(ResourcesDirectoryReadRequestSchema, (request): ServerResult => {
+		const { uri, cursor } = request.params;
+		const listing = readSkillDirectory(catalog, uri, cursor);
+		if (!listing) {
+			throw new McpError(ErrorCode.InvalidParams, `Not a directory resource: ${uri}`);
+		}
+		return listing as ServerResult;
+	});
+
 	const resources = listSkillResources(catalog).length;
-	logger.info({ skills: catalog.skills.length, resources }, 'registered skill resources');
+	logger.info({ skills: catalog.entries.length, resources }, 'registered skill resources');
 }

--- a/packages/app/src/server/skills/skill-types.ts
+++ b/packages/app/src/server/skills/skill-types.ts
@@ -1,27 +1,64 @@
-export type SkillResourceType = 'skill-md' | 'archive';
+// Types for the experimental Skills extension (SEP-2640).
+//
+// The index format follows the Skills Over MCP Working Group decision of 2026-06-05:
+// each `skill://index.json` entry carries a verbatim `frontmatter` object, an optional
+// `url` + `digest` (for individually-addressable skills), and a per-skill `archives[]`
+// array. There is no top-level `name`/`type`/`description`/`$schema`.
 
-export interface SkillResource {
+/** YAML frontmatter of a `SKILL.md`, rendered verbatim as JSON in the index. */
+export interface SkillFrontmatter {
 	name: string;
-	type: SkillResourceType;
 	description: string;
+	[key: string]: unknown;
+}
+
+/** A single readable file resource served over MCP (`resources/read`). */
+export interface ReadableSkillFile {
 	url: string;
-	digest?: string;
 	absPath: string;
 	mimeType: string;
 	isText: boolean;
 }
 
-export interface SkillCompatibilityFile {
-	resourceName: string;
-	url: string;
-	absPath: string;
+/** A file within a skill directory, individually addressable as a resource. */
+export interface SkillResource extends ReadableSkillFile {
+	/** Resource name: the skill `name` for `SKILL.md`, otherwise the file basename. */
+	name: string;
+	/** Only the `SKILL.md` resource carries a description (from frontmatter). */
+	description?: string;
+}
+
+/** A pre-packed archive form of an entire skill directory. */
+export interface SkillArchive extends ReadableSkillFile {
+	name: string;
+	digest?: string;
+}
+
+/** A direct child of a directory resource, returned by `resources/directory/read`. */
+export interface SkillDirChild {
+	uri: string;
+	name: string;
 	mimeType: string;
-	isText: boolean;
+}
+
+/** One skill: its frontmatter, addressable files (if any), and archive forms (if any). */
+export interface SkillEntry {
+	/** `<skill-path>` from the URI, e.g. `git-workflow` or `acme/billing/refunds`. */
+	skillPath: string;
+	frontmatter: SkillFrontmatter;
+	/** Present when the skill is individually addressable (has a `url`). */
+	skillMd?: { url: string; digest?: string };
+	/** All files under the skill directory (includes `SKILL.md`); empty for archive-only skills. */
+	files: SkillResource[];
+	archives: SkillArchive[];
 }
 
 export interface SkillCatalog {
 	indexPath: string;
 	indexText: string;
-	skills: SkillResource[];
-	compatibilityFiles: SkillCompatibilityFile[];
+	entries: SkillEntry[];
+	/** Flattened lookup of every readable file (skill files + archives) by URI. */
+	resourcesByUri: Map<string, ReadableSkillFile>;
+	/** Directory URI (no trailing slash) → its direct children, for `resources/directory/read`. */
+	directories: Map<string, SkillDirChild[]>;
 }

--- a/packages/app/src/server/skills/skill-uri.ts
+++ b/packages/app/src/server/skills/skill-uri.ts
@@ -48,8 +48,35 @@ export function mimeFor(relPath: string): { mimeType: string; isText: boolean } 
 	return { mimeType: 'application/octet-stream', isText: false };
 }
 
-export function buildSkillUri(skillName: string, relPath: string): string {
-	const normalised = relPath.replaceAll('\\', '/');
-	const encodedPath = normalised.split('/').map(encodeURIComponent).join('/');
-	return `skill://${encodeURIComponent(skillName)}/${encodedPath}`;
+/** mimeType marking a directory resource (per SEP-2640 `resources/directory/read`). */
+export const DIRECTORY_MIME = 'inode/directory';
+
+function encodeSegments(value: string): string {
+	return value
+		.replaceAll('\\', '/')
+		.split('/')
+		.filter((segment) => segment.length > 0)
+		.map(encodeURIComponent)
+		.join('/');
+}
+
+/**
+ * Build a `skill://` resource URI. `skillPath` may be a single segment (`git-workflow`)
+ * or nested (`acme/billing/refunds`); `relPath` is the file path relative to the skill
+ * directory root. Each segment is URL-encoded individually.
+ */
+export function buildSkillUri(skillPath: string, relPath: string): string {
+	const encodedSkill = encodeSegments(skillPath);
+	const encodedPath = encodeSegments(relPath);
+	return `skill://${encodedSkill}/${encodedPath}`;
+}
+
+/**
+ * Build a directory resource URI (no trailing slash). `relDir` is the directory path
+ * relative to the skill root; an empty `relDir` yields the skill root directory URI.
+ */
+export function buildSkillDirUri(skillPath: string, relDir: string): string {
+	const encodedSkill = encodeSegments(skillPath);
+	const encodedDir = encodeSegments(relDir);
+	return encodedDir ? `skill://${encodedSkill}/${encodedDir}` : `skill://${encodedSkill}`;
 }

--- a/packages/app/src/server/transport/stateless-http-transport.ts
+++ b/packages/app/src/server/transport/stateless-http-transport.ts
@@ -21,14 +21,20 @@ import { logSystemEvent } from '../utils/query-logger.js';
 import { rewriteLegacySearchToolCallRequest } from '../utils/repo-search-shim.js';
 import { isClientDenied } from '../../shared/client-denylist.js';
 import { getSkillCatalog } from '../skills/skill-catalog-cache.js';
-import { listSkillResources, readSkillResource } from '../skills/skill-resource-data.js';
+import { listSkillResources, readSkillResource, readSkillDirectory } from '../skills/skill-resource-data.js';
+import { RESOURCES_DIRECTORY_READ_METHOD } from '../skills/skill-directory-schema.js';
 import { getProxyToolsConfig } from '../utils/proxy-tools-config.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 // Resource methods that build the full server and thus expose the Skills surface.
-const RESOURCE_METHODS = new Set(['resources/list', 'resources/read', 'resources/templates/list']);
+const RESOURCE_METHODS = new Set([
+	'resources/list',
+	'resources/read',
+	'resources/templates/list',
+	RESOURCES_DIRECTORY_READ_METHOD,
+]);
 // Resource-subscription methods we never support (skills are static — nothing to
 // notify `resources/updated` about). Rejected cheaply before any server is built.
 const UNSUPPORTED_SUBSCRIBE_METHODS = new Set(['resources/subscribe', 'resources/unsubscribe']);
@@ -38,6 +44,7 @@ interface JsonRpcRequestBody {
 	id?: string | number | null;
 	params?: {
 		uri?: unknown;
+		cursor?: unknown;
 		clientInfo?: unknown;
 		capabilities?: unknown;
 		name?: string;
@@ -140,7 +147,7 @@ export class StatelessHttpTransport extends BaseTransport {
 		if (isClientDenied(clientInfo?.name, req.headers['user-agent'])) return false;
 
 		const catalog = await getSkillCatalog();
-		if (!catalog?.skills.length) return false;
+		if (!catalog?.entries.length) return false;
 
 		const id = extractJsonRpcId(req.body);
 
@@ -185,6 +192,24 @@ export class StatelessHttpTransport extends BaseTransport {
 				},
 			});
 			this.trackMethodCall('resources/read', startTime, false, clientInfo);
+			return true;
+		}
+
+		if (method === RESOURCES_DIRECTORY_READ_METHOD && typeof uri === 'string' && uri.startsWith('skill://')) {
+			const cursor = typeof requestBody?.params?.cursor === 'string' ? requestBody.params.cursor : undefined;
+			const listing = readSkillDirectory(catalog, uri, cursor);
+			if (!listing) {
+				res.status(200).json(JsonRpcErrors.invalidParams(`Not a directory resource: ${uri}`, id));
+				this.trackMethodCall(RESOURCES_DIRECTORY_READ_METHOD, startTime, true, clientInfo);
+				return true;
+			}
+
+			res.status(200).json({
+				jsonrpc: '2.0',
+				id,
+				result: listing,
+			});
+			this.trackMethodCall(RESOURCES_DIRECTORY_READ_METHOD, startTime, false, clientInfo);
 			return true;
 		}
 

--- a/packages/app/src/server/utils/capability-utils.ts
+++ b/packages/app/src/server/utils/capability-utils.ts
@@ -59,7 +59,13 @@ export function registerCapabilities(
 		...(hasSkills
 			? {
 					extensions: {
-						'io.modelcontextprotocol/skills': {},
+						// SEP-2640 capability declaration. We implement the optional
+						// `resources/directory/read` method, so advertise `directoryRead: true`.
+						// The non-empty object also sidesteps the empty-object → `[]` JSON
+						// serialization gotcha reported in experimental-ext-skills PR #95.
+						'io.modelcontextprotocol/skills': {
+							directoryRead: true,
+						},
 					},
 				}
 			: {}),

--- a/packages/app/test/server/capability-utils.test.ts
+++ b/packages/app/test/server/capability-utils.test.ts
@@ -24,7 +24,7 @@ describe('registerCapabilities', () => {
 		registerCapabilities(server, apiClient, { hasSkills: true });
 		const caps = getCaps();
 		expect(caps.resources).toEqual({ subscribe: false, listChanged: false });
-		expect(caps.extensions).toEqual({ 'io.modelcontextprotocol/skills': {} });
+		expect(caps.extensions).toEqual({ 'io.modelcontextprotocol/skills': { directoryRead: true } });
 	});
 
 	it('advertises no resources or skills extension for a denied client (hasSkills/hasResources false)', () => {

--- a/packages/app/test/server/skill-loader.test.ts
+++ b/packages/app/test/server/skill-loader.test.ts
@@ -7,18 +7,7 @@ import { loadSkills } from '../../src/server/skills/skill-loader.js';
 let root: string;
 
 async function writeIndex(skills: unknown[]): Promise<void> {
-	await writeFile(
-		path.join(root, 'index.json'),
-		JSON.stringify(
-			{
-				$schema: 'https://schemas.agentskills.io/discovery/0.2.0/schema.json',
-				skills,
-			},
-			null,
-			2,
-		),
-		'utf8',
-	);
+	await writeFile(path.join(root, 'index.json'), JSON.stringify({ skills }, null, 2), 'utf8');
 }
 
 beforeEach(async () => {
@@ -30,144 +19,160 @@ afterEach(async () => {
 });
 
 describe('loadSkills', () => {
-	it('loads skill resources from a prebuilt distribution index', async () => {
-		await mkdir(path.join(root, 'alpha'), { recursive: true });
+	it('loads a skill, walks its directory, and exposes supporting files as resources', async () => {
+		await mkdir(path.join(root, 'alpha', 'references'), { recursive: true });
 		await writeFile(path.join(root, 'alpha', 'SKILL.md'), '# alpha\n', 'utf8');
-		await writeFile(path.join(root, 'beta.tar.gz'), Buffer.from([0x1f, 0x8b]));
+		await writeFile(path.join(root, 'alpha', 'references', 'guide.md'), '# guide\n', 'utf8');
+		await writeFile(path.join(root, 'alpha.tar.gz'), Buffer.from([0x1f, 0x8b]));
 		await writeIndex([
 			{
-				name: 'alpha',
-				type: 'skill-md',
-				description: 'first skill',
 				url: 'skill://alpha/SKILL.md',
 				digest: 'sha256:abc',
-			},
-			{
-				name: 'beta',
-				type: 'archive',
-				description: 'second skill',
-				url: 'skill://beta.tar.gz',
+				frontmatter: { name: 'alpha', description: 'first skill' },
+				archives: [{ url: 'skill://alpha.tar.gz', mimeType: 'application/gzip', digest: 'sha256:arch' }],
 			},
 		]);
 
 		const catalog = await loadSkills(root);
 
 		expect(catalog.indexPath).toBe(path.join(root, 'index.json'));
-		expect(catalog.indexText).toContain('agentskills');
-		expect(catalog.skills).toMatchObject([
-			{
-				name: 'alpha',
-				type: 'skill-md',
-				description: 'first skill',
-				url: 'skill://alpha/SKILL.md',
-				digest: 'sha256:abc',
-				mimeType: 'text/markdown',
-				isText: true,
-			},
-			{
-				name: 'beta',
-				type: 'archive',
-				description: 'second skill',
-				url: 'skill://beta.tar.gz',
-				mimeType: 'application/gzip',
-				isText: false,
-			},
+		expect(catalog.entries).toHaveLength(1);
+		const entry = catalog.entries[0];
+		expect(entry.skillPath).toBe('alpha');
+		expect(entry.frontmatter).toEqual({ name: 'alpha', description: 'first skill' });
+		expect(entry.skillMd).toEqual({ url: 'skill://alpha/SKILL.md', digest: 'sha256:abc' });
+
+		// SKILL.md + the supporting file are both individually addressable.
+		expect([...catalog.resourcesByUri.keys()].sort()).toEqual([
+			'skill://alpha.tar.gz',
+			'skill://alpha/SKILL.md',
+			'skill://alpha/references/guide.md',
 		]);
+
+		const skillMd = catalog.resourcesByUri.get('skill://alpha/SKILL.md');
+		expect(skillMd).toMatchObject({ mimeType: 'text/markdown', isText: true });
+
+		const archive = catalog.resourcesByUri.get('skill://alpha.tar.gz');
+		expect(archive).toMatchObject({ mimeType: 'application/gzip', isText: false });
 	});
 
-	it('ignores sibling source skills tree resources and only loads distribution index entries', async () => {
-		const bucketRoot = path.join(root, 'bucket');
-		const distributionRoot = path.join(bucketRoot, 'distribution', 'latest');
-		const sourceSkillRoot = path.join(bucketRoot, 'skills', 'alpha');
-		await mkdir(path.join(distributionRoot, 'alpha'), { recursive: true });
-		await mkdir(path.join(sourceSkillRoot, 'assets'), { recursive: true });
-		await writeFile(path.join(distributionRoot, 'alpha', 'SKILL.md'), '# alpha distribution\n', 'utf8');
-		await writeFile(path.join(sourceSkillRoot, 'SKILL.md'), '# alpha source\n', 'utf8');
-		await writeFile(path.join(sourceSkillRoot, 'assets', 'diagram.png'), Buffer.from([0x89, 0x50]));
-		await writeFile(
-			path.join(distributionRoot, 'index.json'),
-			JSON.stringify({
-				skills: [
-					{
-						name: 'alpha',
-						type: 'skill-md',
-						description: 'first skill',
-						url: 'skill://alpha/SKILL.md',
-					},
-				],
-			}),
-			'utf8',
-		);
+	it('records directory children for resources/directory/read', async () => {
+		await mkdir(path.join(root, 'alpha', 'scripts'), { recursive: true });
+		await writeFile(path.join(root, 'alpha', 'SKILL.md'), '# alpha\n', 'utf8');
+		await writeFile(path.join(root, 'alpha', 'scripts', 'run.py'), 'print(1)\n', 'utf8');
+		await writeIndex([
+			{
+				url: 'skill://alpha/SKILL.md',
+				digest: 'sha256:abc',
+				frontmatter: { name: 'alpha', description: 'first skill' },
+			},
+		]);
 
-		const catalog = await loadSkills(distributionRoot);
+		const catalog = await loadSkills(root);
 
-		expect(catalog.skills.map((s) => s.url)).toEqual(['skill://alpha/SKILL.md']);
-		expect(catalog.compatibilityFiles).toEqual([]);
+		const rootDir = catalog.directories.get('skill://alpha');
+		expect(rootDir).toBeDefined();
+		expect(rootDir).toContainEqual({ uri: 'skill://alpha/SKILL.md', name: 'SKILL.md', mimeType: 'text/markdown' });
+		expect(rootDir).toContainEqual({ uri: 'skill://alpha/scripts', name: 'scripts', mimeType: 'inode/directory' });
+
+		const scriptsDir = catalog.directories.get('skill://alpha/scripts');
+		expect(scriptsDir).toEqual([{ uri: 'skill://alpha/scripts/run.py', name: 'run.py', mimeType: 'text/x-python' }]);
+	});
+
+	it('supports nested skill paths whose final segment equals frontmatter.name', async () => {
+		await mkdir(path.join(root, 'acme', 'billing', 'refunds'), { recursive: true });
+		await writeFile(path.join(root, 'acme', 'billing', 'refunds', 'SKILL.md'), '# refunds\n', 'utf8');
+		await writeIndex([
+			{
+				url: 'skill://acme/billing/refunds/SKILL.md',
+				digest: 'sha256:abc',
+				frontmatter: { name: 'refunds', description: 'process refunds' },
+			},
+		]);
+
+		const catalog = await loadSkills(root);
+
+		expect(catalog.entries[0].skillPath).toBe('acme/billing/refunds');
+		expect(catalog.resourcesByUri.has('skill://acme/billing/refunds/SKILL.md')).toBe(true);
+		expect(catalog.directories.has('skill://acme/billing/refunds')).toBe(true);
+	});
+
+	it('loads an archive-only skill (no url)', async () => {
+		await writeFile(path.join(root, 'beta.tar.gz'), Buffer.from([0x1f, 0x8b]));
+		await writeIndex([
+			{
+				frontmatter: { name: 'beta', description: 'archive only' },
+				archives: [{ url: 'skill://beta.tar.gz', mimeType: 'application/gzip', digest: 'sha256:beta' }],
+			},
+		]);
+
+		const catalog = await loadSkills(root);
+
+		expect(catalog.entries).toHaveLength(1);
+		expect(catalog.entries[0].skillMd).toBeUndefined();
+		expect(catalog.entries[0].files).toEqual([]);
+		expect([...catalog.resourcesByUri.keys()]).toEqual(['skill://beta.tar.gz']);
 	});
 
 	it('returns an empty catalog when the index does not exist', async () => {
 		const catalog = await loadSkills(path.join(root, 'does-not-exist'));
-		expect(catalog.skills).toEqual([]);
-		expect(catalog.compatibilityFiles).toEqual([]);
+		expect(catalog.entries).toEqual([]);
+		expect(catalog.resourcesByUri.size).toBe(0);
 	});
 
 	it('returns an empty catalog when the index is invalid JSON', async () => {
 		await writeFile(path.join(root, 'index.json'), '{nope', 'utf8');
-
 		const catalog = await loadSkills(root);
-
-		expect(catalog.skills).toEqual([]);
+		expect(catalog.entries).toEqual([]);
 	});
 
-	it('skips invalid entries and missing resource files', async () => {
+	it('skips entries missing frontmatter, missing files, or with no url/archives', async () => {
 		await mkdir(path.join(root, 'valid'), { recursive: true });
 		await writeFile(path.join(root, 'valid', 'SKILL.md'), '# valid\n', 'utf8');
 		await writeIndex([
-			{
-				name: 'valid',
-				type: 'skill-md',
-				description: 'ok',
-				url: 'skill://valid/SKILL.md',
-			},
-			{
-				name: 'missing',
-				type: 'archive',
-				description: 'not present',
-				url: 'skill://missing.tar.gz',
-			},
-			{
-				name: 'bad',
-				type: 'unknown',
-				description: 'bad type',
-				url: 'skill://bad/SKILL.md',
-			},
+			{ url: 'skill://valid/SKILL.md', digest: 'sha256:ok', frontmatter: { name: 'valid', description: 'ok' } },
+			// missing SKILL.md on disk
+			{ url: 'skill://missing/SKILL.md', digest: 'sha256:x', frontmatter: { name: 'missing', description: 'gone' } },
+			// no frontmatter
+			{ url: 'skill://nofm/SKILL.md', digest: 'sha256:x' },
+			// neither url nor archives
+			{ frontmatter: { name: 'empty', description: 'nothing' } },
 		]);
 
 		const catalog = await loadSkills(root);
 
-		expect(catalog.skills.map((s) => s.name)).toEqual(['valid']);
+		expect(catalog.entries.map((e) => e.frontmatter.name)).toEqual(['valid']);
+	});
+
+	it('skips entries whose final skill-path segment does not match frontmatter.name', async () => {
+		await mkdir(path.join(root, 'mismatch'), { recursive: true });
+		await writeFile(path.join(root, 'mismatch', 'SKILL.md'), '# x\n', 'utf8');
+		await writeIndex([
+			{ url: 'skill://mismatch/SKILL.md', digest: 'sha256:x', frontmatter: { name: 'different', description: 'd' } },
+		]);
+
+		const catalog = await loadSkills(root);
+
+		expect(catalog.entries).toEqual([]);
 	});
 
 	it('rejects skill URLs that escape the distribution root', async () => {
 		await writeFile(path.join(root, 'outside.md'), '# outside\n', 'utf8');
 		await writeIndex([
-			{
-				name: 'escape',
-				type: 'skill-md',
-				description: 'bad path',
-				url: 'skill://../outside.md',
-			},
+			{ url: 'skill://../outside.md', digest: 'sha256:x', frontmatter: { name: 'escape', description: 'bad' } },
 		]);
 
 		const catalog = await loadSkills(root);
 
-		expect(catalog.skills).toEqual([]);
+		expect(catalog.entries).toEqual([]);
 	});
 
-	it('skips symlinked resource files', async () => {
-		const target = path.join(root, 'target.md');
-		const link = path.join(root, 'linked.md');
-		await writeFile(target, '# target\n', 'utf8');
+	it('skips symlinked files while walking a skill directory', async () => {
+		await mkdir(path.join(root, 'alpha'), { recursive: true });
+		await writeFile(path.join(root, 'alpha', 'SKILL.md'), '# alpha\n', 'utf8');
+		const target = path.join(root, 'alpha', 'real.md');
+		const link = path.join(root, 'alpha', 'linked.md');
+		await writeFile(target, '# real\n', 'utf8');
 		try {
 			await symlink(target, link);
 		} catch (err) {
@@ -175,16 +180,12 @@ describe('loadSkills', () => {
 			throw err;
 		}
 		await writeIndex([
-			{
-				name: 'linked',
-				type: 'skill-md',
-				description: 'symlink',
-				url: 'skill://linked.md',
-			},
+			{ url: 'skill://alpha/SKILL.md', digest: 'sha256:x', frontmatter: { name: 'alpha', description: 'a' } },
 		]);
 
 		const catalog = await loadSkills(root);
 
-		expect(catalog.skills).toEqual([]);
+		expect(catalog.resourcesByUri.has('skill://alpha/real.md')).toBe(true);
+		expect(catalog.resourcesByUri.has('skill://alpha/linked.md')).toBe(false);
 	});
 });

--- a/packages/app/test/server/skill-resources.test.ts
+++ b/packages/app/test/server/skill-resources.test.ts
@@ -5,9 +5,11 @@ import path from 'node:path';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { loadSkills } from '../../src/server/skills/skill-loader.js';
 import { registerSkillResources } from '../../src/server/skills/skill-resources.js';
+import { RESOURCES_DIRECTORY_READ_METHOD } from '../../src/server/skills/skill-directory-schema.js';
 
 type ResourceContent = { uri: string; mimeType: string; text?: string; blob?: string };
 type ResourceHandler = () => Promise<{ contents: ResourceContent[] }>;
+type RequestHandler = (request: { method: string; params: Record<string, unknown> }) => unknown;
 
 interface Registration {
 	name: string;
@@ -16,47 +18,47 @@ interface Registration {
 	handler: ResourceHandler;
 }
 
-function makeMockServer(): { server: McpServer; calls: Registration[] } {
+function makeMockServer(): {
+	server: McpServer;
+	calls: Registration[];
+	requestHandlers: Map<string, RequestHandler>;
+} {
 	const calls: Registration[] = [];
+	const requestHandlers = new Map<string, RequestHandler>();
+	const inner = {
+		setRequestHandler(schema: { shape: { method: { value: string } } }, handler: RequestHandler) {
+			requestHandlers.set(schema.shape.method.value, handler);
+		},
+	};
 	const server = {
-		registerResource(
-			name: string,
-			uri: string,
-			metadata: Registration['metadata'],
-			handler: ResourceHandler,
-		): void {
+		registerResource(name: string, uri: string, metadata: Registration['metadata'], handler: ResourceHandler): void {
 			calls.push({ name, uri, metadata, handler });
 		},
+		server: inner,
 	} as unknown as McpServer;
-	return { server, calls };
+	return { server, calls, requestHandlers };
 }
 
-async function writeIndex(root: string): Promise<void> {
+async function buildAlphaSkill(root: string): Promise<void> {
+	await mkdir(path.join(root, 'alpha', 'references'), { recursive: true });
+	await writeFile(path.join(root, 'alpha', 'SKILL.md'), '# alpha\n', 'utf8');
+	await writeFile(path.join(root, 'alpha', 'references', 'guide.md'), '# guide\n', 'utf8');
+	await writeFile(path.join(root, 'beta.tar.gz'), Buffer.from([0x1f, 0x8b, 0x08]));
 	await writeFile(
 		path.join(root, 'index.json'),
-		JSON.stringify(
-			{
-				$schema: 'https://schemas.agentskills.io/discovery/0.2.0/schema.json',
-				skills: [
-					{
-						name: 'alpha',
-						type: 'skill-md',
-						description: 'first skill',
-						url: 'skill://alpha/SKILL.md',
-						digest: 'sha256:alpha',
-					},
-					{
-						name: 'beta',
-						type: 'archive',
-						description: 'archive skill',
-						url: 'skill://beta.tar.gz',
-						digest: 'sha256:beta',
-					},
-				],
-			},
-			null,
-			2,
-		),
+		JSON.stringify({
+			skills: [
+				{
+					url: 'skill://alpha/SKILL.md',
+					digest: 'sha256:alpha',
+					frontmatter: { name: 'alpha', description: 'first skill' },
+				},
+				{
+					frontmatter: { name: 'beta', description: 'archive skill' },
+					archives: [{ url: 'skill://beta.tar.gz', mimeType: 'application/gzip', digest: 'sha256:beta' }],
+				},
+			],
+		}),
 		'utf8',
 	);
 }
@@ -72,18 +74,15 @@ afterEach(async () => {
 });
 
 describe('registerSkillResources', () => {
-	it('registers the prebuilt index and each referenced distribution file', async () => {
-		await mkdir(path.join(root, 'alpha'), { recursive: true });
-		await writeFile(path.join(root, 'alpha', 'SKILL.md'), '# alpha\n', 'utf8');
-		await writeFile(path.join(root, 'beta.tar.gz'), Buffer.from([0x1f, 0x8b, 0x08]));
-		await writeIndex(root);
-
+	it('registers every skill file, the archive, and the index', async () => {
+		await buildAlphaSkill(root);
 		const catalog = await loadSkills(root);
 		const { server, calls } = makeMockServer();
 		registerSkillResources(server, catalog);
 
 		expect(calls.map((c) => c.uri).sort()).toEqual([
 			'skill://alpha/SKILL.md',
+			'skill://alpha/references/guide.md',
 			'skill://beta.tar.gz',
 			'skill://index.json',
 		]);
@@ -93,79 +92,66 @@ describe('registerSkillResources', () => {
 		expect(skillMdReg.metadata.description).toBe('first skill');
 		expect(skillMdReg.metadata.mimeType).toBe('text/markdown');
 
+		const supportReg = calls.find((c) => c.uri === 'skill://alpha/references/guide.md')!;
+		expect(supportReg.name).toBe('guide.md');
+		expect(supportReg.metadata.mimeType).toBe('text/markdown');
+
 		const archiveReg = calls.find((c) => c.uri === 'skill://beta.tar.gz')!;
 		expect(archiveReg.name).toBe('beta.tar.gz');
-		expect(archiveReg.metadata.description).toBe('archive skill');
 		expect(archiveReg.metadata.mimeType).toBe('application/gzip');
 	});
 
-	it('does not register source-tree files outside the distribution index', async () => {
-		const bucketRoot = path.join(root, 'bucket');
-		const distributionRoot = path.join(bucketRoot, 'distribution', 'latest');
-		const sourceSkillRoot = path.join(bucketRoot, 'skills', 'alpha');
-		await mkdir(path.join(distributionRoot, 'alpha'), { recursive: true });
-		await mkdir(path.join(sourceSkillRoot, 'assets'), { recursive: true });
-		await writeFile(path.join(distributionRoot, 'alpha', 'SKILL.md'), '# alpha distribution\n', 'utf8');
-		await writeFile(path.join(distributionRoot, 'beta.tar.gz'), Buffer.from([0x1f, 0x8b, 0x08]));
-		await writeFile(path.join(sourceSkillRoot, 'SKILL.md'), '# alpha source\n', 'utf8');
-		await writeFile(path.join(sourceSkillRoot, 'assets', 'notes.txt'), 'compat notes', 'utf8');
-		await writeIndex(distributionRoot);
-
-		const catalog = await loadSkills(distributionRoot);
+	it('serves text for files and base64 blobs for archives', async () => {
+		await buildAlphaSkill(root);
+		const catalog = await loadSkills(root);
 		const { server, calls } = makeMockServer();
 		registerSkillResources(server, catalog);
 
-		expect(calls.map((c) => c.uri).sort()).toEqual([
-			'skill://alpha/SKILL.md',
-			'skill://beta.tar.gz',
-			'skill://index.json',
-		]);
+		const skillMdBody = (await calls.find((c) => c.uri === 'skill://alpha/SKILL.md')!.handler()).contents[0];
+		expect(skillMdBody.mimeType).toBe('text/markdown');
+		expect(skillMdBody.text).toBe('# alpha\n');
+		expect(skillMdBody.blob).toBeUndefined();
 
-		const skillMdRegs = calls.filter((c) => c.uri === 'skill://alpha/SKILL.md');
-		expect(skillMdRegs).toHaveLength(1);
-
-		expect(calls.find((c) => c.uri === 'skill://alpha/assets/notes.txt')).toBeUndefined();
+		const archiveBody = (await calls.find((c) => c.uri === 'skill://beta.tar.gz')!.handler()).contents[0];
+		expect(archiveBody.mimeType).toBe('application/gzip');
+		expect(archiveBody.text).toBeUndefined();
+		expect(archiveBody.blob).toBe(Buffer.from([0x1f, 0x8b, 0x08]).toString('base64'));
 	});
 
 	it('serves index.json exactly as provided by the distribution', async () => {
-		await mkdir(path.join(root, 'alpha'), { recursive: true });
-		await writeFile(path.join(root, 'alpha', 'SKILL.md'), '# alpha\n', 'utf8');
-		await writeFile(path.join(root, 'beta.tar.gz'), Buffer.from([0x1f, 0x8b, 0x08]));
-		await writeIndex(root);
-
+		await buildAlphaSkill(root);
 		const catalog = await loadSkills(root);
 		const { server, calls } = makeMockServer();
 		registerSkillResources(server, catalog);
 
 		const index = calls.find((c) => c.uri === 'skill://index.json')!;
-		const indexBody = (await index.handler()).contents[0];
-		expect(indexBody.mimeType).toBe('application/json');
-		expect(indexBody.text).toBe(catalog.indexText);
-		expect(indexBody.blob).toBeUndefined();
+		const body = (await index.handler()).contents[0];
+		expect(body.mimeType).toBe('application/json');
+		expect(body.text).toBe(catalog.indexText);
 	});
 
-	it('returns text content for skill-md resources and base64 blobs for archives', async () => {
-		const skillMd = '# alpha\n';
-		const archiveBytes = Buffer.from([0x1f, 0x8b, 0x08]);
-		await mkdir(path.join(root, 'alpha'), { recursive: true });
-		await writeFile(path.join(root, 'alpha', 'SKILL.md'), skillMd, 'utf8');
-		await writeFile(path.join(root, 'beta.tar.gz'), archiveBytes);
-		await writeIndex(root);
-
+	it('installs a resources/directory/read handler that lists children and errors on non-directories', async () => {
+		await buildAlphaSkill(root);
 		const catalog = await loadSkills(root);
-		const { server, calls } = makeMockServer();
+		const { server, requestHandlers } = makeMockServer();
 		registerSkillResources(server, catalog);
 
-		const skillMdReg = calls.find((c) => c.uri === 'skill://alpha/SKILL.md')!;
-		const skillMdBody = (await skillMdReg.handler()).contents[0];
-		expect(skillMdBody.mimeType).toBe('text/markdown');
-		expect(skillMdBody.text).toBe(skillMd);
-		expect(skillMdBody.blob).toBeUndefined();
+		const handler = requestHandlers.get(RESOURCES_DIRECTORY_READ_METHOD)!;
+		expect(handler).toBeDefined();
 
-		const archiveReg = calls.find((c) => c.uri === 'skill://beta.tar.gz')!;
-		const archiveBody = (await archiveReg.handler()).contents[0];
-		expect(archiveBody.mimeType).toBe('application/gzip');
-		expect(archiveBody.text).toBeUndefined();
-		expect(archiveBody.blob).toBe(archiveBytes.toString('base64'));
+		const rootListing = handler({
+			method: RESOURCES_DIRECTORY_READ_METHOD,
+			params: { uri: 'skill://alpha' },
+		}) as { resources: { uri: string; mimeType: string }[] };
+		expect(rootListing.resources).toContainEqual({
+			uri: 'skill://alpha/references',
+			name: 'references',
+			mimeType: 'inode/directory',
+		});
+
+		// Non-directory URI → JSON-RPC InvalidParams (-32602).
+		expect(() =>
+			handler({ method: RESOURCES_DIRECTORY_READ_METHOD, params: { uri: 'skill://alpha/SKILL.md' } }),
+		).toThrowError(/Not a directory/);
 	});
 });

--- a/packages/app/test/server/skill-uri.test.ts
+++ b/packages/app/test/server/skill-uri.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { buildSkillUri, mimeFor } from '../../src/server/skills/skill-uri.js';
+import { buildSkillDirUri, buildSkillUri, DIRECTORY_MIME, mimeFor } from '../../src/server/skills/skill-uri.js';
 
 describe('buildSkillUri', () => {
 	it('produces a skill uri for a single file', () => {
@@ -12,6 +12,26 @@ describe('buildSkillUri', () => {
 
 	it('encodes skill names and path segments', () => {
 		expect(buildSkillUri('my skill', 'assets/foo bar(1).png')).toBe('skill://my%20skill/assets/foo%20bar(1).png');
+	});
+
+	it('encodes each segment of a nested skill path', () => {
+		expect(buildSkillUri('acme/billing/refunds', 'SKILL.md')).toBe('skill://acme/billing/refunds/SKILL.md');
+	});
+});
+
+describe('buildSkillDirUri', () => {
+	it('returns the skill root directory uri with no trailing slash', () => {
+		expect(buildSkillDirUri('my-skill', '')).toBe('skill://my-skill');
+		expect(buildSkillDirUri('acme/billing/refunds', '')).toBe('skill://acme/billing/refunds');
+	});
+
+	it('appends a relative directory path', () => {
+		expect(buildSkillDirUri('my-skill', 'references')).toBe('skill://my-skill/references');
+		expect(buildSkillDirUri('my-skill', 'templates/regional')).toBe('skill://my-skill/templates/regional');
+	});
+
+	it('exposes the directory mime constant', () => {
+		expect(DIRECTORY_MIME).toBe('inode/directory');
 	});
 });
 


### PR DESCRIPTION
Updates the Skills-over-MCP implementation to the current SEP-2640 wire contract (WG decisions 2026-06-05 index schema + 2026-06-09 directory read).

## Changes
- Parse the new `skill://index.json`: per-entry verbatim `frontmatter`, optional `url` + `digest`, and per-skill `archives[]` (drops the old `name`/`type`/`$schema` 0.2.0 discovery shape).
- Walk each skill directory so every supporting file is an individually-addressable `skill://` resource.
- Implement `resources/directory/read` (paginated, `inode/directory` listings) in both the stateless fast-path and the full McpServer; advertise `io.modelcontextprotocol/skills: { directoryRead: true }`.
- Support nested skill paths whose final segment equals frontmatter `name`.

Server parses the new index format only, so it requires a distribution produced in that format.

## Testing
- 284 unit tests pass; typecheck + lint clean.
- Verified end-to-end against a live deploy: `initialize` capability, per-file `resources/list`, `resources/directory/read` (happy path + `-32602` on non-directories), supporting-file read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)