### PR TITLE
fix(app): keep loopback hosts in configured allowlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ The server respects the following environment variables:
 - `TRANSPORT`: The transport type to use (stdio, streamableHttp, or streamableHttpJson)
 - `DEFAULT_HF_TOKEN`: Default token for local STDIO deployments. HTTP transports do not use this as a fallback for requests without an `Authorization: Bearer` header.
 - If running with `stdio` transport, `HF_TOKEN` is used if `DEFAULT_HF_TOKEN` is not set.
-- `MCP_ALLOWED_HOSTS`: Comma-separated Host allowlist for MCP and API routes. Defaults to `localhost,127.0.0.1,::1`. Use exact hostnames or leading wildcard entries such as `*.example.com`.
+- `MCP_ALLOWED_HOSTS`: Additional comma-separated Host allowlist for MCP and API routes. Loopback hosts `localhost,127.0.0.1,::1` are always allowed. Use exact hostnames or leading wildcard entries such as `*.example.com`.
 - `HF_API_TIMEOUT`: Timeout for Hugging Face API requests in milliseconds (default: 12500ms / 12.5 seconds)
 - `USER_CONFIG_API`: URL to use for User settings (defaults to Local front-end)
 - `ALLOW_INTERNAL_ADDRESS_HOSTS`: Optional comma-separated host allowlist to permit internal/reserved DNS resolutions for trusted domains during outbound checks (supports exact hosts and `*.` wildcards, for example: `huggingface.co,*.hf.space`).

--- a/packages/app/src/server/utils/inbound-request-security.ts
+++ b/packages/app/src/server/utils/inbound-request-security.ts
@@ -3,7 +3,7 @@ import { CORS_ALLOWED_ORIGINS } from '../../shared/constants.js';
 import { matchesCorsOrigin, normalizeCorsOrigin } from './cors-origin.js';
 import { logger } from './logger.js';
 
-const DEFAULT_ALLOWED_HOSTS = ['localhost', '127.0.0.1', '::1'];
+const LOOPBACK_HOSTS = ['localhost', '127.0.0.1', '::1'];
 
 function parseCsv(value: string | undefined): string[] {
 	return (value || '')
@@ -54,7 +54,7 @@ function hostMatches(host: string, allowlist: string[]): boolean {
 
 function getAllowedHosts(): string[] {
 	const configured = parseCsv(process.env.MCP_ALLOWED_HOSTS);
-	return configured.length > 0 ? configured : DEFAULT_ALLOWED_HOSTS;
+	return [...LOOPBACK_HOSTS, ...configured];
 }
 
 function getAllowedOrigins(): string[] {

--- a/packages/app/test/server/utils/inbound-request-security.test.ts
+++ b/packages/app/test/server/utils/inbound-request-security.test.ts
@@ -35,6 +35,18 @@ describe('validateInboundRequest', () => {
 		expect(validateInboundRequest(request({ host: '[::1]:3000' }))).toEqual({ allowed: true });
 	});
 
+	it('keeps loopback Host headers allowed when deployment hosts are configured', () => {
+		process.env.MCP_ALLOWED_HOSTS = 'mcp.example.com';
+
+		expect(validateInboundRequest(request({ host: 'localhost:3000' }))).toEqual({ allowed: true });
+		expect(validateInboundRequest(request({ host: '127.0.0.1:3000' }))).toEqual({ allowed: true });
+		expect(validateInboundRequest(request({ host: '[::1]:3000' }))).toEqual({ allowed: true });
+		expect(validateInboundRequest(request({ host: 'attacker.example:3000' }))).toEqual({
+			allowed: false,
+			reason: 'Host attacker.example is not allowed',
+		});
+	});
+
 	it('rejects attacker Host headers by default', () => {
 		expect(validateInboundRequest(request({ host: 'attacker.example:3000' }))).toEqual({
 			allowed: false,


### PR DESCRIPTION
## Summary

- keep `localhost`, `127.0.0.1`, and `::1` allowed when `MCP_ALLOWED_HOSTS` is configured
- add regression coverage for configured deployment hosts and loopback requests
- clarify the additive allowlist behavior in the environment variable documentation

## Why

Follow-up to #195 and its P1 review finding.

Configuring `MCP_ALLOWED_HOSTS` for a public deployment replaced the loopback defaults. The server's own `McpApiClient` polls `/api/settings` through `localhost`, so those internal requests received `403 Forbidden`. Authenticated sessions could then fall back to reduced tool settings instead of using dashboard settings.

Making the loopback entries invariant preserves internal polling while continuing to reject unrelated hosts. Authentication and anonymous-access behavior are unchanged.

## Validation

- `pnpm -C packages/app test` — 337 tests passed
- `pnpm -C packages/app typecheck`
- `pnpm exec prettier --check README.md packages/app/src/server/utils/inbound-request-security.ts packages/app/test/server/utils/inbound-request-security.test.ts`
