### PR TITLE
Tolerate minor hf_fs variants and trim the research bouquet

### DIFF
--- a/packages/app/src/shared/bouquet-presets.ts
+++ b/packages/app/src/shared/bouquet-presets.ts
@@ -46,13 +46,7 @@ export const BOUQUETS: Record<string, AppSettings> = {
 		spaceTools: [],
 	},
 	research: {
-		builtInTools: [
-			HF_FILES_FLAG,
-			...TOOL_ID_GROUPS.sandbox,
-			...TOOL_ID_GROUPS.docs,
-			CREATE_REPO_TOOL_ID,
-			HUB_REPO_DETAILS_TOOL_ID,
-		],
+		builtInTools: [HF_FILES_FLAG, ...TOOL_ID_GROUPS.sandbox, CREATE_REPO_TOOL_ID, HUB_REPO_DETAILS_TOOL_ID],
 		spaceTools: [],
 	},
 	all: {

--- a/packages/app/test/server/utils/tool-selection-strategy.test.ts
+++ b/packages/app/test/server/utils/tool-selection-strategy.test.ts
@@ -11,6 +11,8 @@ import type { TransportInfo } from '../../../src/shared/transport-info.js';
 import {
 	ALL_BUILTIN_TOOL_IDS,
 	CREATE_REPO_TOOL_ID,
+	DOC_FETCH_TOOL_ID,
+	DOCS_SEMANTIC_SEARCH_TOOL_ID,
 	HF_FILES_FLAG,
 	HF_FS_TOOL_ID,
 	HF_SANDBOX_EXEC_TOOL_ID,
@@ -168,11 +170,13 @@ describe('BOUQUETS configuration', () => {
 			expect(bouquet.builtInTools).toEqual([
 				HF_FILES_FLAG,
 				...TOOL_ID_GROUPS.sandbox,
-				...TOOL_ID_GROUPS.docs,
 				CREATE_REPO_TOOL_ID,
 				HUB_REPO_DETAILS_TOOL_ID,
 			]);
-			expect(normalizeBuiltInTools(bouquet.builtInTools)).toContain(HF_FS_TOOL_ID);
+			const normalized = normalizeBuiltInTools(bouquet.builtInTools);
+			expect(normalized).toContain(HF_FS_TOOL_ID);
+			expect(normalized).not.toContain(DOCS_SEMANTIC_SEARCH_TOOL_ID);
+			expect(normalized).not.toContain(DOC_FETCH_TOOL_ID);
 			expect(bouquet.spaceTools).toEqual([]);
 		}
 	});

--- a/packages/mcp/src/hf-fs-contract.test.ts
+++ b/packages/mcp/src/hf-fs-contract.test.ts
@@ -46,17 +46,19 @@ describe('parseHfFsRequest', () => {
 			uri: 'hf://models/org/repo',
 			limit: 5,
 		});
-		expect(
-			parseHfFsRequest({
-				cmd: 'find',
-				args: ['hf://models/org/repo', '--glob', '*.json', '-limit', '5'],
-			}).params
-		).toEqual({
-			op: 'find',
-			uri: 'hf://models/org/repo',
-			name: '*.json',
-			limit: 5,
-		});
+		for (const recursive of ['-R', '-r', '--recursive']) {
+			expect(
+				parseHfFsRequest({
+					cmd: 'find',
+					args: ['hf://models/org/repo', recursive, '--glob', '*.json', '-limit', '5'],
+				}).params
+			).toEqual({
+				op: 'find',
+				uri: 'hf://models/org/repo',
+				name: '*.json',
+				limit: 5,
+			});
+		}
 		expect(
 			parseHfFsRequest({
 				cmd: 'cat',
@@ -70,7 +72,22 @@ describe('parseHfFsRequest', () => {
 		});
 	});
 
-	it('joins relative cat paths and multi-token search queries', () => {
+	it('accepts combined long-list recursion flags', () => {
+		for (const flag of ['-lR', '-laR']) {
+			expect(
+				parseHfFsRequest({
+					cmd: 'ls',
+					args: [flag, 'hf://models/org/repo'],
+				}).params
+			).toEqual({
+				op: 'ls',
+				uri: 'hf://models/org/repo',
+				recursive: true,
+			});
+		}
+	});
+
+	it('joins relative cat and stat paths and multi-token search queries', () => {
 		expect(
 			parseHfFsRequest({
 				cmd: 'cat',
@@ -80,6 +97,15 @@ describe('parseHfFsRequest', () => {
 			op: 'cat',
 			uri: 'hf://models/org/repo/README.md',
 			max_bytes: 100,
+		});
+		expect(
+			parseHfFsRequest({
+				cmd: 'stat',
+				args: ['hf://models/org/repo', 'model.safetensors.index.json'],
+			}).params
+		).toEqual({
+			op: 'stat',
+			uri: 'hf://models/org/repo/model.safetensors.index.json',
 		});
 		expect(
 			parseHfFsRequest({

--- a/packages/mcp/src/hf-fs-contract.ts
+++ b/packages/mcp/src/hf-fs-contract.ts
@@ -40,11 +40,11 @@ export interface HfFsParams {
 export const HF_FS_DESCRIPTION = `Use to access the Hugging Face Hub. Navigate resources with ls, cat, find, stat, and search over hf:// URIs. Roots: hf://models, hf://datasets, hf://spaces, hf://buckets, hf://collections, hf://papers, hf://docs. For papers, ls hf://papers/ARXIV_ID to discover related resources; cat hf://papers/ARXIV_ID/paper.md or metadata.json. Documentation paths include the current version from each product's llms.txt manifest.
 
 Grammar; each token below is one args array element:
-  ls     URI [(-R|-r|--recursive)] [(-l|-a|-la|-al|--long)] [--glob GLOB]
+  ls     URI [(-R|-r|-lR|-laR|--recursive)] [(-l|-a|-la|-al|--long)] [--glob GLOB]
              [(-type|--type|--entry-type) TYPE] [--sort SORT] [(-limit|--limit) N]
   cat    URI [RELATIVE_PATH] [(-offset|--offset) N] [(-max-bytes|--max-bytes) N]
-  stat   URI
-  find   URI [(-name|--name|--glob) GLOB] [(-path|--path) GLOB]
+  stat   URI [RELATIVE_PATH]
+  find   URI [(-R|-r|--recursive)] [(-name|--name|--glob) GLOB] [(-path|--path) GLOB]
              [(-type|--type|--entry-type) TYPE] [(-limit|--limit) N]
   search URI [QUERY...] [(-type|--type|--entry-type) TYPE] [--sort SORT]
                         [--tag TAG] [--kind mcp] [(-limit|--limit) N]
@@ -55,8 +55,9 @@ SORT = createdAt|downloads|likes|lastModified|likes30d|trendingScore|mainSize|id
 URI starts with hf://. QUERY and GLOB are each one string token.
 Search URI: hf://models|datasets|spaces[/OWNER], hf://collections[/OWNER], any hf://docs scope, or exactly hf://papers; not hf://.
 Repository and collection searches may omit QUERY to browse or filter; documentation and paper searches require it.
-Search joins multiple positional QUERY tokens with spaces. Cat joins one RELATIVE_PATH token to URI.
+Search joins multiple positional QUERY tokens with spaces. Cat and stat join one RELATIVE_PATH token to URI.
 Long-list flags are accepted for compatibility; hf_fs listings are already structured, so they do not alter output.
+Find is already recursive, so recursive flags are accepted without altering behavior.
 Space search: hf://spaces uses semantic search; repeat --tag to require tags, or use --kind mcp for --tag mcp-server. hf://spaces/OWNER uses owner-scoped keyword search.
 Documentation: ls hf://docs for products; search any docs scope; use returned hf:// URIs verbatim.
 Trending listings: ls hf://models/trending, hf://datasets/trending, or hf://spaces/trending. They return up to 20 entries.
@@ -91,6 +92,8 @@ const TYPE_ALIASES: Readonly<Record<string, HfFsEntryType>> = {
 const LS_FLAGS: CommandOptionMap = {
 	'-R': { key: 'recursive', kind: 'boolean' },
 	'-r': { key: 'recursive', kind: 'boolean' },
+	'-lR': { key: 'recursive', kind: 'boolean' },
+	'-laR': { key: 'recursive', kind: 'boolean' },
 	'--recursive': { key: 'recursive', kind: 'boolean' },
 	'-l': { key: 'long', kind: 'boolean' },
 	'-a': { key: 'all', kind: 'boolean' },
@@ -114,6 +117,9 @@ const CAT_FLAGS: CommandOptionMap = {
 };
 
 const FIND_FLAGS: CommandOptionMap = {
+	'-R': { key: 'recursive_compat', kind: 'boolean' },
+	'-r': { key: 'recursive_compat', kind: 'boolean' },
+	'--recursive': { key: 'recursive_compat', kind: 'boolean' },
 	'-name': { key: 'name', kind: 'string' },
 	'--name': { key: 'name', kind: 'string' },
 	'--glob': { key: 'name', kind: 'string' },
@@ -156,10 +162,11 @@ export function parseHfFsRequest(request: HfFsRequest): ParsedHfFsRequest {
 	if (!uri?.startsWith('hf://')) {
 		throw new Error('EINVAL: URI must start with hf://');
 	}
-	if (request.cmd === 'cat' && positionals.length === 2) {
+	if ((request.cmd === 'cat' || request.cmd === 'stat') && positionals.length === 2) {
 		uri = joinUriPath(uri, positionals[1] ?? '');
 	}
-	const expectedPositionals = request.cmd === 'search' ? Number.POSITIVE_INFINITY : request.cmd === 'cat' ? 2 : 1;
+	const expectedPositionals =
+		request.cmd === 'search' ? Number.POSITIVE_INFINITY : request.cmd === 'cat' || request.cmd === 'stat' ? 2 : 1;
 	if (positionals.length > expectedPositionals) {
 		throw new Error(`EINVAL: unexpected argument for ${request.cmd}: ${positionals[expectedPositionals] ?? ''}`);
 	}


### PR DESCRIPTION
## Summary

### `hf_fs` parser compatibility
- accept combined `ls -lR` and `ls -laR` flags
- join one relative path argument for `stat`, matching `cat` compatibility behavior
- accept `-R`, `-r`, and `--recursive` as no-ops for already-recursive `find`
- update the grammar and add focused parser coverage

### Research bouquet
- remove the redundant `hf_doc_search` and `hf_doc_fetch` tools
- retain documentation search and reading through `hf_fs`
- reduce measured authenticated fast-agent overhead from 2,446 to about 2,270 input tokens per model call

## Validation

- MCP package: 370 tests passed
- App package: 337 tests passed
- focused tool-selection suite: 61 tests passed
- typecheck and ESLint passed for both changed packages
- Prettier and `git diff --check` passed

## Local fast-agent measurement

Authenticated research bouquet now advertises eight MCP tools:

- `hf_whoami`
- `hf_create_repo`
- `hub_repo_details`
- `hf_fs`
- `hf_fs_write`
- `hf_sandbox`
- `hf_sandbox_exec`
- `hf_sandbox_fs`

Anonymous users receive `hf_whoami`, `hub_repo_details`, and `hf_fs`.