### PR TITLE
Trim legacy docs tools from research bouquet

### DIFF
--- a/packages/app/src/shared/bouquet-presets.ts
+++ b/packages/app/src/shared/bouquet-presets.ts
@@ -46,13 +46,7 @@ export const BOUQUETS: Record<string, AppSettings> = {
 		spaceTools: [],
 	},
 	research: {
-		builtInTools: [
-			HF_FILES_FLAG,
-			...TOOL_ID_GROUPS.sandbox,
-			...TOOL_ID_GROUPS.docs,
-			CREATE_REPO_TOOL_ID,
-			HUB_REPO_DETAILS_TOOL_ID,
-		],
+		builtInTools: [HF_FILES_FLAG, ...TOOL_ID_GROUPS.sandbox, CREATE_REPO_TOOL_ID, HUB_REPO_DETAILS_TOOL_ID],
 		spaceTools: [],
 	},
 	all: {

--- a/packages/app/test/server/utils/tool-selection-strategy.test.ts
+++ b/packages/app/test/server/utils/tool-selection-strategy.test.ts
@@ -11,6 +11,8 @@ import type { TransportInfo } from '../../../src/shared/transport-info.js';
 import {
 	ALL_BUILTIN_TOOL_IDS,
 	CREATE_REPO_TOOL_ID,
+	DOC_FETCH_TOOL_ID,
+	DOCS_SEMANTIC_SEARCH_TOOL_ID,
 	HF_FILES_FLAG,
 	HF_FS_TOOL_ID,
 	HF_SANDBOX_EXEC_TOOL_ID,
@@ -168,11 +170,13 @@ describe('BOUQUETS configuration', () => {
 			expect(bouquet.builtInTools).toEqual([
 				HF_FILES_FLAG,
 				...TOOL_ID_GROUPS.sandbox,
-				...TOOL_ID_GROUPS.docs,
 				CREATE_REPO_TOOL_ID,
 				HUB_REPO_DETAILS_TOOL_ID,
 			]);
-			expect(normalizeBuiltInTools(bouquet.builtInTools)).toContain(HF_FS_TOOL_ID);
+			const normalized = normalizeBuiltInTools(bouquet.builtInTools);
+			expect(normalized).toContain(HF_FS_TOOL_ID);
+			expect(normalized).not.toContain(DOCS_SEMANTIC_SEARCH_TOOL_ID);
+			expect(normalized).not.toContain(DOC_FETCH_TOOL_ID);
 			expect(bouquet.spaceTools).toEqual([]);
 		}
 	});


### PR DESCRIPTION
## Summary

- remove `hf_doc_search` and `hf_doc_fetch` from the research bouquet
- retain documentation search and reading through `hf_fs`
- assert both legacy doc tools remain absent after bouquet normalization

This reduces the research bouquet tool-schema budget without removing documentation capabilities.

## Validation

- `pnpm exec vitest run packages/app/test/server/utils/tool-selection-strategy.test.ts` — 61 tests passed
- `pnpm -C packages/app test` — 337 tests passed
- `pnpm -C packages/app typecheck`
- `pnpm -C packages/app lint:check`
- Prettier and `git diff --check`