### PR TITLE
fix: improve MCP observability and protocol UX

### DIFF
--- a/packages/app/src/server/mcp-server.ts
+++ b/packages/app/src/server/mcp-server.ts
@@ -56,6 +56,7 @@ import { getSkillCatalog } from './skills/skill-catalog-cache.js';
 import { SERVER_VERSION } from './server-build-info.js';
 import { parseDisabledTools } from './utils/disabled-tools.js';
 import { createProgressRelay } from './utils/progress-relay.js';
+import { getToolResultErrorMessage } from './utils/observability.js';
 
 // Bouquet configurations moved to tool-selection-strategy.ts
 
@@ -150,19 +151,6 @@ export const createServerFactory = (sharedApiClient: McpApiClient): ServerFactor
 			config: QueryLoggingConfig<T>,
 			work: () => Promise<T>
 		): Promise<T> => {
-			const getToolResultErrorMessage = (result: T): string | undefined => {
-				if (typeof result !== 'object' || result === null || !('isError' in result)) {
-					return undefined;
-				}
-				if (!(result as { isError?: boolean }).isError) {
-					return undefined;
-				}
-				if ('formatted' in result && typeof (result as { formatted?: unknown }).formatted === 'string') {
-					return (result as { formatted: string }).formatted;
-				}
-				return 'Tool returned an error result';
-			};
-
 			const start = performance.now();
 			try {
 				const result = await work();
@@ -793,6 +781,7 @@ export const createServerFactory = (sharedApiClient: McpApiClient): ServerFactor
 								responseCharCount: toolResult.formatted.length,
 								durationMs,
 								success,
+								...(toolResult.isError ? { error: getToolResultErrorMessage(toolResult) } : {}),
 							});
 
 							return {

--- a/packages/app/src/server/transport/stateless-http-transport.ts
+++ b/packages/app/src/server/transport/stateless-http-transport.ts
@@ -30,6 +30,7 @@ import { listSkillResources, readSkillResource, readSkillDirectory } from '../sk
 import { RESOURCES_DIRECTORY_READ_METHOD } from '../skills/skill-directory-schema.js';
 import { getProxyToolsConfig } from '../utils/proxy-tools-config.js';
 import { BOUQUET_FALLBACK } from '../../shared/settings.js';
+import { getErrorLogFields } from '../utils/observability.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -365,7 +366,17 @@ export class StatelessHttpTransport extends BaseTransport {
 				);
 				result.server.server.onerror = (error) => {
 					this.trackError(undefined, error);
-					logger.error({ error }, 'Modern HTTP MCP server error');
+					logger.error(
+						{
+							...getErrorLogFields(error),
+							requestId: requestData.requestId,
+							protocolEra: 'modern',
+							protocolVersion: requestData.protocolVersion,
+							clientName: requestData.clientInfo?.name,
+							clientVersion: requestData.clientInfo?.version,
+						},
+						'Modern HTTP MCP server error'
+					);
 				};
 				return result.server;
 			},
@@ -373,7 +384,18 @@ export class StatelessHttpTransport extends BaseTransport {
 				legacy: 'reject',
 				responseMode: 'auto',
 				onerror: (error) => {
-					logger.error({ error }, 'Modern HTTP MCP handler error');
+					const requestData = this.modernRequestStorage.getStore();
+					logger.error(
+						{
+							...getErrorLogFields(error),
+							requestId: requestData?.requestId,
+							protocolEra: 'modern',
+							protocolVersion: requestData?.protocolVersion,
+							clientName: requestData?.clientInfo?.name,
+							clientVersion: requestData?.clientInfo?.version,
+						},
+						'Modern HTTP MCP handler error'
+					);
 				},
 			}
 		);

--- a/packages/app/src/server/utils/observability.ts
+++ b/packages/app/src/server/utils/observability.ts
@@ -1,0 +1,63 @@
+export interface ErrorLogFields {
+	err: unknown;
+	errorMessage: string;
+	errorName?: string;
+	errorCode?: string | number;
+}
+
+function stringifyUnknown(value: unknown): string {
+	if (typeof value === 'string') return value;
+
+	try {
+		const serialized = JSON.stringify(value);
+		if (serialized && serialized !== '{}') return serialized;
+	} catch {
+		// Fall through for circular or otherwise non-serializable values.
+	}
+
+	return String(value);
+}
+
+/**
+ * Put Error objects under Pino's conventional `err` key so its standard
+ * serializer retains message, name, and stack. Duplicate useful scalar fields
+ * because the dataset transport stores bindings in a generic `data` field.
+ */
+export function getErrorLogFields(error: unknown): ErrorLogFields {
+	const errorObject = typeof error === 'object' && error !== null ? error : undefined;
+	const errorCode =
+		errorObject && 'code' in errorObject && ['string', 'number'].includes(typeof errorObject.code)
+			? (errorObject.code as string | number)
+			: undefined;
+
+	if (error instanceof Error) {
+		return {
+			err: error,
+			errorMessage: error.message,
+			errorName: error.name,
+			...(errorCode !== undefined ? { errorCode } : {}),
+		};
+	}
+
+	return {
+		err: error,
+		errorMessage: stringifyUnknown(error),
+		...(errorCode !== undefined ? { errorCode } : {}),
+	};
+}
+
+/**
+ * MCP tools may report an expected failure as a handler result with
+ * `isError: true`. Convert that result into useful telemetry.
+ */
+export function getToolResultErrorMessage(result: unknown): string | undefined {
+	if (typeof result !== 'object' || result === null || !('isError' in result) || !result.isError) {
+		return undefined;
+	}
+
+	if ('formatted' in result && typeof result.formatted === 'string' && result.formatted.length > 0) {
+		return result.formatted;
+	}
+
+	return 'Tool returned an error result';
+}

--- a/packages/app/src/web/components/StatelessTransportMetrics.tsx
+++ b/packages/app/src/web/components/StatelessTransportMetrics.tsx
@@ -98,6 +98,16 @@ export function StatelessTransportMetrics({ metrics }: StatelessTransportMetrics
 		.filter((method) => method.method === 'tools/call' || method.method.startsWith('tools/call:'))
 		.reduce((sum, method) => sum + method.count, 0);
 	const recentClients = metrics.clients.filter((client) => isRecentlyActive(client.lastSeen)).length;
+	const protocolFilterOptions = Array.from(
+		new Map(
+			metrics.clients.flatMap((client) =>
+				client.protocols.map((protocol) => {
+					const value = `${protocol.era}:${protocol.version}`;
+					return [value, { value, label: `${protocol.era} · ${protocol.version}` }] as const;
+				})
+			)
+		).values()
+	).sort((a, b) => b.value.localeCompare(a.value));
 
 	// Define columns for the client identities table
 	const createClientColumns = (): ColumnDef<ClientData>[] => [
@@ -120,6 +130,8 @@ export function StatelessTransportMetrics({ metrics }: StatelessTransportMetrics
 		{
 			id: 'protocols',
 			header: 'Protocol',
+			filterFn: (row, _columnId, filterValue: string) =>
+				row.original.protocols.some((protocol) => `${protocol.era}:${protocol.version}` === filterValue),
 			cell: ({ row }) => (
 				<div className="flex flex-col gap-1">
 					{row.original.protocols.map((protocol) => (
@@ -307,6 +319,11 @@ export function StatelessTransportMetrics({ metrics }: StatelessTransportMetrics
 						data={clientData}
 						searchColumn="name"
 						searchPlaceholder="Filter clients..."
+						facetFilter={{
+							column: 'protocols',
+							label: 'All protocol versions',
+							options: protocolFilterOptions,
+						}}
 						pageSize={50}
 						defaultSorting={[{ id: 'lastSeen', desc: true }]}
 					/>

--- a/packages/app/src/web/components/data-table.tsx
+++ b/packages/app/src/web/components/data-table.tsx
@@ -27,6 +27,11 @@ interface DataTableProps<TData, TValue> {
 	data: TData[];
 	searchColumn?: string;
 	searchPlaceholder?: string;
+	facetFilter?: {
+		column: string;
+		label: string;
+		options: Array<{ label: string; value: string }>;
+	};
 	defaultColumnVisibility?: VisibilityState;
 	pageSize?: number;
 	defaultSorting?: SortingState;
@@ -37,6 +42,7 @@ export function DataTable<TData, TValue>({
 	data,
 	searchColumn,
 	searchPlaceholder = 'Filter...',
+	facetFilter,
 	defaultColumnVisibility = {},
 	pageSize = 25,
 	defaultSorting = [],
@@ -82,6 +88,21 @@ export function DataTable<TData, TValue>({
 						onChange={(event) => table.getColumn(searchColumn)?.setFilterValue(event.target.value)}
 						className="w-full sm:max-w-sm"
 					/>
+				)}
+				{facetFilter && (
+					<select
+						aria-label={facetFilter.label}
+						value={(table.getColumn(facetFilter.column)?.getFilterValue() as string) ?? ''}
+						onChange={(event) => table.getColumn(facetFilter.column)?.setFilterValue(event.target.value || undefined)}
+						className="h-9 w-full rounded-md border border-input bg-background px-3 text-sm shadow-xs outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 sm:w-auto sm:min-w-52"
+					>
+						<option value="">{facetFilter.label}</option>
+						{facetFilter.options.map((option) => (
+							<option key={option.value} value={option.value}>
+								{option.label}
+							</option>
+						))}
+					</select>
 				)}
 				<DropdownMenu>
 					<DropdownMenuTrigger asChild>

--- a/packages/app/test/server/utils/observability.test.ts
+++ b/packages/app/test/server/utils/observability.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { getErrorLogFields, getToolResultErrorMessage } from '../../../src/server/utils/observability.js';
+
+describe('getErrorLogFields', () => {
+	it('retains Error details for Pino and dataset logging', () => {
+		const error = Object.assign(new Error('modern handler failed'), { code: 'HANDLER_FAILURE' });
+
+		expect(getErrorLogFields(error)).toEqual({
+			err: error,
+			errorMessage: 'modern handler failed',
+			errorName: 'Error',
+			errorCode: 'HANDLER_FAILURE',
+		});
+	});
+
+	it('describes non-Error values', () => {
+		const error = { reason: 'invalid modern request', code: 400 };
+
+		expect(getErrorLogFields(error)).toEqual({
+			err: error,
+			errorMessage: '{"reason":"invalid modern request","code":400}',
+			errorCode: 400,
+		});
+	});
+});
+
+describe('getToolResultErrorMessage', () => {
+	it('uses a dynamic tool error result formatted message', () => {
+		expect(
+			getToolResultErrorMessage({
+				isError: true,
+				formatted: 'Input validation error: text_input is required',
+			})
+		).toBe('Input validation error: text_input is required');
+	});
+
+	it('uses a fallback when an error result has no formatted message', () => {
+		expect(getToolResultErrorMessage({ isError: true, formatted: '' })).toBe('Tool returned an error result');
+		expect(getToolResultErrorMessage({ isError: false, formatted: 'ok' })).toBeUndefined();
+	});
+});


### PR DESCRIPTION
## Summary

- preserve modern MCP handler/server error message, name, stack, and error code using Pino's standard `err` serialization
- attach modern request correlation fields when available: request ID, protocol version, and client implementation
- persist the formatted failure message when `dynamic_space` returns an `isError` tool result instead of throwing
- add an exact protocol-version filter to the Overview client implementations table
- add a stacked exact-version adoption chart with request share, era, and request-count legend
- add focused tests for Error/non-Error serialization and tool-result failure extraction

## Motivation

The first production hour after the v0.3.36 rollout showed two modern handler errors persisted only as `{"error":{}}`, and two failed `dynamic_space` query events with no `errorMessage`. This makes it impossible to distinguish malformed client traffic from actionable server failures.

The protocol rollout also makes it useful to isolate client implementations observed on a specific wire version directly from the dashboard.

## Error categorization follow-up

This PR does not label method errors as internal rejections versus upstream failures. The in-memory method metrics currently receive only an `isError` boolean; MCP tool failures are returned over HTTP 200 and do not carry structured provenance through that path. Classifying them from message text would be misleading. The improved persisted error details in this PR provide the information needed to add an explicit error-origin field at the tool boundary in a follow-up.

## Validation

- `pnpm -C packages/app test` — 335 passed
- `pnpm -C packages/app lint:check`
- `pnpm -C packages/app typecheck`
- `pnpm -C packages/app build`
- legacy and modern HTTP smoke scripts
- desktop Chrome screenshot of the protocol filter
- desktop and mobile Chrome inspection of the exact-version chart
- Prettier and `git diff --check`
