### PR TITLE
fix(app): harden auth, proxy, and telemetry edge cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ The server respects the following environment variables:
 - `MCP_STRICT_COMPLIANCE`: set to True for GET 405 rejects in JSON Mode (default serves a welcome page).
 - `DISABLE_TOOLS`: Optional comma-separated tool names to hide from `tools/list` and reject if called, for example `hub_repo_search,hf_fs`. Rejected calls remain visible as errors in the MCP dashboard tool-call statistics.
 - `PROXY_TOOLS_CSV`: Optional CSV that defines Streamable HTTP proxy tool sources (see below).
+- `PROXY_TOKEN`: Optional token used only for startup authentication while discovering `PROXY_TOOLS_CSV` schemas.
 - `GRADIO_SKIP_INITIALIZE`: When set to `true`, Gradio MCP calls skip the `initialize` handshake and issue `tools/call` directly.
 - `HF_SKILLS_DIR`: Local directory containing a prebuilt skills distribution in the [SEP-2640](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2640) index format (a `skill://index.json` whose entries carry verbatim `frontmatter`, an optional `url` + `digest`, and an `archives[]` array, alongside the expanded `SKILL.md`/supporting-file tree and `.tar.gz` archives). The server walks each skill directory and exposes every file as an individual `skill://` resource, supports `resources/directory/read` for scoped navigation, and advertises the `io.modelcontextprotocol/skills` extension with `directoryRead: true`. Defaults to `/mnt/hf-skills/distribution/latest`, intended for a Hugging Face Space volume mounted from `hf://buckets/huggingface/skills`.
 
@@ -233,6 +234,8 @@ hf spaces variables add <org>/<space> -e HF_SKILLS_DIR=/mnt/hf-skills/distributi
 ### Proxy tools (Streamable HTTP via CSV)
 
 You can load proxy tool definitions at startup by setting `PROXY_TOOLS_CSV` to a **HTTPS URL** or a **local file path**.
+If those proxy servers require authentication, set `PROXY_TOKEN`. User, default, and logging tokens are never used
+for startup proxy schema discovery.
 The server fetches each MCP endpoint once on startup, runs `initialize` + `tools/list` (10s timeout), and registers any tools returned.
 If a source fails or returns no tools, it is skipped (no startup failure).
 

--- a/packages/app/src/server/utils/auth-utils.ts
+++ b/packages/app/src/server/utils/auth-utils.ts
@@ -30,8 +30,9 @@ export function extractAuthBouquetAndMix(
 		// Extract token from Authorization header
 		if ('authorization' in headers) {
 			const authHeader = headers.authorization || '';
-			if (authHeader.startsWith('Bearer ')) {
-				tokenFromHeader = authHeader.slice(7).trim();
+			const bearerMatch = authHeader.match(/^Bearer\s+(\S+)\s*$/i);
+			if (bearerMatch?.[1]) {
+				tokenFromHeader = bearerMatch[1].trim();
 			}
 		}
 

--- a/packages/app/src/server/utils/hf-dataset-transport.ts
+++ b/packages/app/src/server/utils/hf-dataset-transport.ts
@@ -100,21 +100,29 @@ export class HfDatasetLogger {
 			return;
 		}
 
-		const logsToUpload = [...this.logBuffer];
+		// Detach the current batch so records received during the upload remain
+		// buffered for the next flush.
+		const logsToUpload = this.logBuffer.splice(0, this.logBuffer.length);
 		this.uploadInProgress = true;
+		let uploadSucceeded = false;
 
 		console.log(`[HF Dataset ${this.logType}] Starting upload of ${logsToUpload.length} logs`);
 
 		try {
 			await this.uploadLogs(logsToUpload);
-			// Only clear buffer after successful upload
-			this.logBuffer = [];
+			uploadSucceeded = true;
 			console.log(`[HF Dataset ${this.logType}] ✅ Uploaded ${logsToUpload.length} logs to ${this.datasetId}`);
 		} catch (error) {
-			// Keep logs in buffer for retry on next flush cycle
+			// Restore the failed batch ahead of records that arrived while it
+			// was uploading, while retaining the configured buffer bound.
+			this.logBuffer = [...logsToUpload, ...this.logBuffer].slice(-this.maxBufferSize);
 			console.error(`[HF Dataset ${this.logType}] ❌ Upload failed, will retry on next flush:`, error);
 		} finally {
 			this.uploadInProgress = false;
+		}
+
+		if (uploadSucceeded && this.logBuffer.length >= this.batchSize) {
+			void this.flush();
 		}
 	}
 
@@ -123,10 +131,14 @@ export class HfDatasetLogger {
 		const filename = `logs-${timestamp}-${this.sessionId}.jsonl`;
 
 		const dateFolder = new Date().toISOString().split('T')[0];
-		const folder = this.logType === 'Query' ? 'queries' 
-			: this.logType === 'System' ? 'sessions' 
-			: this.logType === 'Gradio' ? 'gradio'
-			: 'logs';
+		const folder =
+			this.logType === 'Query'
+				? 'queries'
+				: this.logType === 'System'
+					? 'sessions'
+					: this.logType === 'Gradio'
+						? 'gradio'
+						: 'logs';
 		const pathInRepo = `${folder}/${dateFolder}/${filename}`;
 
 		console.log(`[HF Dataset ${this.logType}] Uploading to path: ${pathInRepo}`);

--- a/packages/app/src/server/utils/proxy-tools-config.ts
+++ b/packages/app/src/server/utils/proxy-tools-config.ts
@@ -38,6 +38,7 @@ interface ProxyToolSchemaProperty {
 }
 
 const PROXY_TOOLS_ENV_VAR = 'PROXY_TOOLS_CSV';
+const PROXY_TOKEN_ENV_VAR = 'PROXY_TOKEN';
 const VALID_RESPONSE_TYPES = new Set<ProxyToolResponseType>(['JSON', 'SSE']);
 const PROXY_SCHEMA_TIMEOUT_MS = 10_000;
 
@@ -112,7 +113,7 @@ async function loadProxyToolSchemas(sources: ProxyToolSource[]): Promise<ProxyTo
 		return [];
 	}
 
-	const hfToken = process.env.DEFAULT_HF_TOKEN || process.env.HF_TOKEN || process.env.LOGGING_HF_TOKEN;
+	const hfToken = getProxyToken();
 	const schemaTasks = sources.map((source) =>
 		Promise.race([fetchProxyToolSchemas(source, hfToken), createTimeout(PROXY_SCHEMA_TIMEOUT_MS)])
 			.then((tools) => ({ source, tools }))
@@ -124,6 +125,10 @@ async function loadProxyToolSchemas(sources: ProxyToolSource[]): Promise<ProxyTo
 
 	const results = await Promise.all(schemaTasks);
 	return results.flatMap((result) => result.tools);
+}
+
+export function getProxyToken(): string | undefined {
+	return process.env[PROXY_TOKEN_ENV_VAR];
 }
 
 async function fetchProxyToolSchemas(

--- a/packages/app/src/server/utils/tool-selection-strategy.ts
+++ b/packages/app/src/server/utils/tool-selection-strategy.ts
@@ -94,6 +94,10 @@ export class ToolSelectionStrategy {
 		return getProxyToolsConfig().map((tool) => tool.toolName);
 	}
 
+	private getProxyConfigIds(): string[] {
+		return getProxyToolsConfig().flatMap((tool) => [tool.proxyId, tool.toolName]);
+	}
+
 	private appendProxyTools(enabledToolIds: string[]): string[] {
 		const proxyToolNames = this.getProxyToolNames();
 		if (proxyToolNames.length === 0) {
@@ -109,7 +113,7 @@ export class ToolSelectionStrategy {
 			HF_FILES_FLAG,
 			README_INCLUDE_FLAG,
 			GRADIO_IMAGE_FILTER_FLAG,
-			...this.getProxyToolNames(),
+			...this.getProxyConfigIds(),
 		]);
 		const unsupportedIds = ids.filter((id) => !supportedIds.has(id));
 		if (unsupportedIds.length > 0) {

--- a/packages/app/test/server/utils/hf-dataset-transport.test.ts
+++ b/packages/app/test/server/utils/hf-dataset-transport.test.ts
@@ -174,21 +174,18 @@ describe('HfDatasetLogger', () => {
 			expect(attemptCount).toBe(2); // Two attempts made
 		});
 
-		it('should not allow concurrent uploads', async () => {
+		it('should serialize concurrent uploads without dropping newly buffered logs', async () => {
 			let uploadCallCount = 0;
+			const uploadResolvers: Array<(result: CommitOutput) => void> = [];
 			const slowUpload = (): Promise<CommitOutput> => {
 				uploadCallCount++;
 				return new Promise((resolve) => {
-					// Auto-resolve after 100ms to prevent hanging
-					setTimeout(
-						() =>
-							resolve({
-								commit: { url: 'test-url', oid: 'test-oid' },
-								hookOutput: 'test-hook-output',
-							}),
-						100
-					);
+					uploadResolvers.push(resolve);
 				});
+			};
+			const uploadResult: CommitOutput = {
+				commit: { url: 'test-url', oid: 'test-oid' },
+				hookOutput: 'test-hook-output',
 			};
 
 			logger = createTestLogger({ uploadFunction: slowUpload, batchSize: 1 });
@@ -196,21 +193,21 @@ describe('HfDatasetLogger', () => {
 			// Add log to trigger flush
 			logger.processLog({ level: 30, time: Date.now(), msg: 'Test 1' });
 
-			// Wait for upload to start
-			await new Promise((resolve) => setTimeout(resolve, 50));
-
-			// Verify upload is in progress
 			expect(logger.getStatus().uploadInProgress).toBe(true);
+			expect(uploadCallCount).toBe(1);
 
 			// Try to flush again while upload is in progress
 			logger.processLog({ level: 30, time: Date.now(), msg: 'Test 2' });
 			await (logger as unknown as { flush: () => Promise<void> }).flush();
-
-			// Wait for completion
-			await new Promise((resolve) => setTimeout(resolve, 150));
-
-			// Should have only one upload call
 			expect(uploadCallCount).toBe(1);
+
+			uploadResolvers[0]?.(uploadResult);
+			await new Promise((resolve) => setImmediate(resolve));
+
+			expect(uploadCallCount).toBe(2);
+			uploadResolvers[1]?.(uploadResult);
+			await new Promise((resolve) => setImmediate(resolve));
+			expect(logger.getStatus().bufferSize).toBe(0);
 		}, 3000);
 	});
 

--- a/packages/app/test/server/utils/proxy-tools-config.test.ts
+++ b/packages/app/test/server/utils/proxy-tools-config.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { getProxyToken } from '../../../src/server/utils/proxy-tools-config.js';
+
+describe('proxy tools authentication', () => {
+	const originalProxyToken = process.env.PROXY_TOKEN;
+	const originalDefaultHfToken = process.env.DEFAULT_HF_TOKEN;
+	const originalHfToken = process.env.HF_TOKEN;
+	const originalLoggingHfToken = process.env.LOGGING_HF_TOKEN;
+
+	afterEach(() => {
+		restoreEnv('PROXY_TOKEN', originalProxyToken);
+		restoreEnv('DEFAULT_HF_TOKEN', originalDefaultHfToken);
+		restoreEnv('HF_TOKEN', originalHfToken);
+		restoreEnv('LOGGING_HF_TOKEN', originalLoggingHfToken);
+	});
+
+	it('uses only PROXY_TOKEN for proxy authentication', () => {
+		process.env.PROXY_TOKEN = 'hf_proxy_token';
+		process.env.DEFAULT_HF_TOKEN = 'hf_default_token';
+		process.env.HF_TOKEN = 'hf_user_token';
+		process.env.LOGGING_HF_TOKEN = 'hf_logging_token';
+
+		expect(getProxyToken()).toBe('hf_proxy_token');
+	});
+
+	it('does not fall back to user, default, or logging tokens', () => {
+		delete process.env.PROXY_TOKEN;
+		process.env.DEFAULT_HF_TOKEN = 'hf_default_token';
+		process.env.HF_TOKEN = 'hf_user_token';
+		process.env.LOGGING_HF_TOKEN = 'hf_logging_token';
+
+		expect(getProxyToken()).toBeUndefined();
+	});
+});
+
+function restoreEnv(name: string, value: string | undefined): void {
+	if (value === undefined) {
+		delete process.env[name];
+	} else {
+		process.env[name] = value;
+	}
+}

--- a/packages/app/test/server/utils/tool-selection-proxy-ids.test.ts
+++ b/packages/app/test/server/utils/tool-selection-proxy-ids.test.ts
@@ -1,0 +1,41 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { McpApiClient } from '../../../src/server/utils/mcp-api-client.js';
+import { ToolSelectionStrategy } from '../../../src/server/utils/tool-selection-strategy.js';
+
+vi.mock('../../../src/server/utils/proxy-tools-config.js', () => ({
+	getProxyToolsConfig: () => [
+		{
+			proxyId: 'multi_tool_proxy',
+			toolName: 'proxy_tool_one',
+			upstreamToolName: 'upstream_one',
+			url: 'https://proxy.example/mcp',
+		},
+		{
+			proxyId: 'multi_tool_proxy',
+			toolName: 'proxy_tool_two',
+			upstreamToolName: 'upstream_two',
+			url: 'https://proxy.example/mcp',
+		},
+	],
+}));
+
+describe('ToolSelectionStrategy proxy source IDs', () => {
+	let strategy: ToolSelectionStrategy;
+
+	beforeEach(() => {
+		strategy = new ToolSelectionStrategy(new McpApiClient({ type: 'static' }));
+	});
+
+	it('preserves a multi-tool proxy source ID returned by external settings', async () => {
+		const result = await strategy.selectTools({
+			headers: {},
+			hfToken: 'hf_test_token',
+			userSettings: {
+				builtInTools: ['multi_tool_proxy'],
+				spaceTools: [],
+			},
+		});
+
+		expect(result.enabledToolIds).toContain('multi_tool_proxy');
+	});
+});

--- a/packages/app/test/server/utils/tool-selection-strategy.test.ts
+++ b/packages/app/test/server/utils/tool-selection-strategy.test.ts
@@ -108,6 +108,19 @@ describe('extractBouquetAndMix', () => {
 
 		expect(result.hfToken).toBe('hf_request_token');
 	});
+
+	it.each(['bearer', 'BEARER', 'BeArEr'])('should parse the %s authorization scheme case-insensitively', (scheme) => {
+		const result = extractAuthBouquetAndMix({ authorization: `${scheme} hf_request_token` });
+
+		expect(result.hfToken).toBe('hf_request_token');
+	});
+
+	it.each(['Bearer', 'Bearer ', 'Basic hf_request_token', 'Bearer token extra'])(
+		'should ignore malformed authorization value %j',
+		(authorization) => {
+			expect(extractAuthBouquetAndMix({ authorization }).hfToken).toBeUndefined();
+		}
+	);
 });
 
 describe('BOUQUETS configuration', () => {


### PR DESCRIPTION
## Summary

- parse the HTTP `Bearer` authorization scheme case-insensitively while continuing to reject malformed values
- preserve telemetry records added while a Hugging Face dataset upload is in flight, and immediately drain a newly full batch after a successful upload
- isolate startup proxy schema discovery to the dedicated `PROXY_TOKEN` and document the setting
- preserve proxy source IDs when external settings enable a proxy that exposes multiple tools

## Tests

- `pnpm -C packages/app test` — 335 passed
- `pnpm -C packages/app typecheck`
- `pnpm -C packages/app lint`
