### PR TITLE
fix: align MCP settings and improve protocol metrics

### DIFF
--- a/packages/app/src/server/transport/base-transport.ts
+++ b/packages/app/src/server/transport/base-transport.ts
@@ -127,6 +127,17 @@ export abstract class BaseTransport {
 		this.metrics.trackClientProtocol(clientInfo, era, version);
 	}
 
+	protected trackProtocolToolCall(
+		method: string | null,
+		era: ProtocolEra,
+		version: string,
+		clientInfo?: { name: string; version: string }
+	): void {
+		if (method?.startsWith('tools/call:')) {
+			this.metrics.trackProtocolToolCall(era, version, clientInfo);
+		}
+	}
+
 	protected trackAuthenticatedUser(
 		username: string | undefined,
 		era: ProtocolEra,

--- a/packages/app/src/server/transport/stateless-http-transport.ts
+++ b/packages/app/src/server/transport/stateless-http-transport.ts
@@ -495,6 +495,7 @@ export class StatelessHttpTransport extends BaseTransport {
 			protocolVersion,
 			clientInfo
 		);
+		this.trackProtocolToolCall(trackingName, 'modern', protocolVersion, clientInfo);
 
 		if (requestBody?.method === 'server/discover') {
 			logSystemEvent('server_discover', requestId, {
@@ -646,6 +647,7 @@ export class StatelessHttpTransport extends BaseTransport {
 			this.updateClientActivity(protocolClientInfo);
 			this.trackClientProtocol(protocolClientInfo, 'legacy', protocolVersion);
 		}
+		this.trackProtocolToolCall(trackingName, 'legacy', protocolVersion, protocolClientInfo);
 
 		if (rpcMethod && UNSUPPORTED_PROMPT_METHODS.has(rpcMethod)) {
 			const promptSessionId = headers['mcp-session-id'];

--- a/packages/app/src/server/utils/auth-utils.ts
+++ b/packages/app/src/server/utils/auth-utils.ts
@@ -30,8 +30,9 @@ export function extractAuthBouquetAndMix(
 		// Extract token from Authorization header
 		if ('authorization' in headers) {
 			const authHeader = headers.authorization || '';
-			if (authHeader.startsWith('Bearer ')) {
-				tokenFromHeader = authHeader.slice(7).trim();
+			const bearerMatch = authHeader.match(/^Bearer\s+(\S+)\s*$/i);
+			if (bearerMatch?.[1]) {
+				tokenFromHeader = bearerMatch[1].trim();
 			}
 		}
 

--- a/packages/app/src/server/web-server.ts
+++ b/packages/app/src/server/web-server.ts
@@ -259,24 +259,27 @@ export class WebServer {
 				// Determine if transport is stateless
 				const isStateless = this.transportInfo.transport === 'streamableHttpJson';
 
-				// Get sessions (empty for stateless transports)
-				const sessions = this.transport.getSessions().map((session) => {
-					const fiveMinutesAgo = new Date(Date.now() - 5 * 60 * 1000);
-					const hasRecentActivity = session.lastActivity > fiveMinutesAgo;
+				// Stateless dashboards use aggregate lifecycle counters. Do not copy and
+				// serialize the unbounded analytics-session map on every metrics poll.
+				const sessions = isStateless
+					? []
+					: this.transport.getSessions().map((session) => {
+							const fiveMinutesAgo = new Date(Date.now() - 5 * 60 * 1000);
+							const hasRecentActivity = session.lastActivity > fiveMinutesAgo;
 
-					return {
-						id: session.id,
-						connectedAt: session.connectedAt.toISOString(),
-						lastActivity: session.lastActivity.toISOString(),
-						requestCount: session.requestCount,
-						clientInfo: session.clientInfo,
-						isConnected: hasRecentActivity,
-						connectionStatus: hasRecentActivity ? ('Connected' as const) : ('Disconnected' as const),
-						ipAddress: session.ipAddress,
-						protocolEra: session.protocolEra,
-						protocolVersion: session.protocolVersion,
-					};
-				});
+							return {
+								id: session.id,
+								connectedAt: session.connectedAt.toISOString(),
+								lastActivity: session.lastActivity.toISOString(),
+								requestCount: session.requestCount,
+								clientInfo: session.clientInfo,
+								isConnected: hasRecentActivity,
+								connectionStatus: hasRecentActivity ? ('Connected' as const) : ('Disconnected' as const),
+								ipAddress: session.ipAddress,
+								protocolEra: session.protocolEra,
+								protocolVersion: session.protocolVersion,
+							};
+						});
 
 				// Format for API response
 				const formattedMetrics = formatMetricsForAPI(metrics, this.transportInfo.transport, isStateless, sessions);

--- a/packages/app/src/shared/transport-metrics.ts
+++ b/packages/app/src/shared/transport-metrics.ts
@@ -7,6 +7,7 @@ interface ProtocolUsageMetrics {
 	era: ProtocolEra;
 	version: string;
 	requestCount: number;
+	toolCallCount: number;
 	firstSeen: Date;
 	lastSeen: Date;
 }
@@ -200,6 +201,7 @@ export interface TransportMetricsResponse {
 		era: ProtocolEra;
 		version: string;
 		requestCount: number;
+		toolCallCount: number;
 		uniqueClients: number;
 		uniqueUsers: number;
 		unattributedRequests: number;
@@ -266,6 +268,7 @@ export interface TransportMetricsResponse {
 			era: ProtocolEra;
 			version: string;
 			requestCount: number;
+			toolCallCount: number;
 			firstSeen: string;
 			lastSeen: string;
 		}>;
@@ -563,6 +566,7 @@ export class MetricsCounter {
 			era,
 			version: normalizedVersion,
 			requestCount: 1,
+			toolCallCount: 0,
 			uniqueClients: 0,
 			uniqueUsers: 0,
 			unattributedRequests: 1,
@@ -590,6 +594,7 @@ export class MetricsCounter {
 				era,
 				version: normalizedVersion,
 				requestCount: 1,
+				toolCallCount: 0,
 				firstSeen: new Date(),
 				lastSeen: new Date(),
 			});
@@ -606,6 +611,25 @@ export class MetricsCounter {
 			aggregate.uniqueClients = clients.size;
 			aggregate.unattributedRequests = Math.max(0, aggregate.unattributedRequests - 1);
 		}
+	}
+
+	/**
+	 * Attribute a tool call to the exact protocol revision used for the request.
+	 */
+	trackProtocolToolCall(
+		era: ProtocolEra,
+		version: string,
+		clientInfo?: { name: string; version: string }
+	): void {
+		const normalizedVersion = this.normalizeProtocolVersion(era, version);
+		const protocolKey = getProtocolKey(era, normalizedVersion);
+		const aggregate = this.metrics.protocolVersions.get(protocolKey);
+		if (aggregate) aggregate.toolCallCount++;
+
+		if (!clientInfo) return;
+		const clientKey = getClientKey(clientInfo.name, clientInfo.version);
+		const clientProtocol = this.metrics.clients.get(clientKey)?.protocols.get(protocolKey);
+		if (clientProtocol) clientProtocol.toolCallCount++;
 	}
 
 	/**

--- a/packages/app/src/web/App.tsx
+++ b/packages/app/src/web/App.tsx
@@ -30,8 +30,9 @@ function App() {
 		revalidateOnReconnect: true,
 	});
 
-	// Use SWR for sessions to trigger stdioClient update
-	useSWR('/api/sessions', fetcher, {
+	// Only STDIO needs the session endpoint to populate stdioClient. HTTP
+	// dashboards use aggregate counters from transport metrics.
+	useSWR(transportInfo?.transport === 'stdio' ? '/api/sessions' : null, fetcher, {
 		refreshInterval: 3000, // Refresh every 3 seconds
 		revalidateOnFocus: true,
 	});

--- a/packages/app/src/web/components/StatelessTransportMetrics.tsx
+++ b/packages/app/src/web/components/StatelessTransportMetrics.tsx
@@ -8,27 +8,17 @@ import { MetricTile, SectionHeader } from './DashboardPrimitives';
 import { formatCompactNumber } from '../lib/dashboard-utils';
 import type { TransportMetricsResponse } from '../../shared/transport-metrics.js';
 
-type ClientData = {
-	name: string;
-	version: string;
+type ClientMetric = TransportMetricsResponse['clients'][number];
+type ClientProtocolMetric = ClientMetric['protocols'][number];
+type ClientProtocolData = Omit<
+	ClientMetric,
+	'protocols' | 'requestCount' | 'toolCallCount' | 'firstSeen' | 'lastSeen'
+> & {
+	protocol: ClientProtocolMetric;
 	requestCount: number;
-	activeConnections: number;
-	totalConnections: number;
-	isConnected: boolean;
-	lastSeen: string;
-	firstSeen: string;
 	toolCallCount: number;
-	newIpCount: number;
-	anonCount: number;
-	uniqueAuthCount: number;
-	uniqueUserCount: number;
-	protocols: Array<{
-		era: 'legacy' | 'modern';
-		version: string;
-		requestCount: number;
-		firstSeen: string;
-		lastSeen: string;
-	}>;
+	firstSeen: string;
+	lastSeen: string;
 };
 
 /**
@@ -89,7 +79,17 @@ interface StatelessTransportMetricsProps {
 }
 
 export function StatelessTransportMetrics({ metrics }: StatelessTransportMetricsProps) {
-	const clientData = metrics.clients;
+	const clientData: ClientProtocolData[] = metrics.clients.flatMap((client) => {
+		const { protocols, ...clientTotals } = client;
+		return protocols.map((protocol) => ({
+			...clientTotals,
+			protocol,
+			requestCount: protocol.requestCount,
+			toolCallCount: protocol.toolCallCount,
+			firstSeen: protocol.firstSeen,
+			lastSeen: protocol.lastSeen,
+		}));
+	});
 	const protocolRequestTotal = metrics.protocolEras.legacy + metrics.protocolEras.modern;
 	const modernShare =
 		protocolRequestTotal === 0 ? 0 : Math.round((metrics.protocolEras.modern / protocolRequestTotal) * 100);
@@ -100,17 +100,15 @@ export function StatelessTransportMetrics({ metrics }: StatelessTransportMetrics
 	const recentClients = metrics.clients.filter((client) => isRecentlyActive(client.lastSeen)).length;
 	const protocolFilterOptions = Array.from(
 		new Map(
-			metrics.clients.flatMap((client) =>
-				client.protocols.map((protocol) => {
-					const value = `${protocol.era}:${protocol.version}`;
-					return [value, { value, label: `${protocol.era} · ${protocol.version}` }] as const;
-				})
-			)
+			clientData.map((client) => {
+				const value = `${client.protocol.era}:${client.protocol.version}`;
+				return [value, { value, label: `${client.protocol.era} · ${client.protocol.version}` }] as const;
+			})
 		).values()
 	).sort((a, b) => b.value.localeCompare(a.value));
 
-	// Define columns for the client identities table
-	const createClientColumns = (): ColumnDef<ClientData>[] => [
+	// Define columns for exact client/protocol combinations.
+	const createClientColumns = (): ColumnDef<ClientProtocolData>[] => [
 		{
 			accessorKey: 'name',
 			header: createSortableHeader('Client'),
@@ -128,23 +126,18 @@ export function StatelessTransportMetrics({ metrics }: StatelessTransportMetrics
 			},
 		},
 		{
-			id: 'protocols',
+			id: 'protocol',
 			header: 'Protocol',
 			filterFn: (row, _columnId, filterValue: string) =>
-				row.original.protocols.some((protocol) => `${protocol.era}:${protocol.version}` === filterValue),
-			cell: ({ row }) => (
-				<div className="flex flex-col gap-1">
-					{row.original.protocols.map((protocol) => (
-						<Badge
-							key={`${protocol.era}:${protocol.version}`}
-							variant={protocol.era === 'modern' ? 'success' : 'secondary'}
-							title={`${protocol.requestCount} requests`}
-						>
-							{protocol.era} · {protocol.version}
-						</Badge>
-					))}
-				</div>
-			),
+				`${row.original.protocol.era}:${row.original.protocol.version}` === filterValue,
+			cell: ({ row }) => {
+				const protocol = row.original.protocol;
+				return (
+					<Badge variant={protocol.era === 'modern' ? 'success' : 'secondary'}>
+						{protocol.era} · {protocol.version}
+					</Badge>
+				);
+			},
 		},
 		{
 			accessorKey: 'requestCount',
@@ -158,16 +151,20 @@ export function StatelessTransportMetrics({ metrics }: StatelessTransportMetrics
 		},
 		{
 			accessorKey: 'newIpCount',
-			header: createSortableHeader('New IPs', 'right'),
-			cell: ({ row }) => <div className="text-right font-mono text-sm">{row.getValue<number>('newIpCount')}</div>,
+			header: createSortableHeader('Client New IPs', 'right'),
+			cell: ({ row }) => (
+				<div className="text-right font-mono text-sm" title="Client-wide total across all protocol versions">
+					{row.getValue<number>('newIpCount')}
+				</div>
+			),
 		},
 		{
 			accessorKey: 'anonCount',
-			header: createSortableHeader('Anon/Tokens/Users', 'right'),
+			header: createSortableHeader('Client Anon/Tokens/Users', 'right'),
 			cell: ({ row }) => {
 				const client = row.original;
 				return (
-					<div className="text-right font-mono text-sm">
+					<div className="text-right font-mono text-sm" title="Client-wide totals across all protocol versions">
 						{client.anonCount}/{client.uniqueAuthCount}/{client.uniqueUserCount}
 					</div>
 				);
@@ -312,7 +309,7 @@ export function StatelessTransportMetrics({ metrics }: StatelessTransportMetrics
 				<CardContent>
 					<SectionHeader
 						title="Client implementations"
-						description="Live protocol adoption, activity, authentication, and tool usage by client."
+						description="One row per implementation and exact protocol version, with protocol-attributed requests and tool calls."
 					/>
 					<DataTable
 						columns={createClientColumns()}
@@ -320,7 +317,7 @@ export function StatelessTransportMetrics({ metrics }: StatelessTransportMetrics
 						searchColumn="name"
 						searchPlaceholder="Filter clients..."
 						facetFilter={{
-							column: 'protocols',
+							column: 'protocol',
 							label: 'All protocol versions',
 							options: protocolFilterOptions,
 						}}

--- a/packages/app/test/server/utils/tool-selection-strategy.test.ts
+++ b/packages/app/test/server/utils/tool-selection-strategy.test.ts
@@ -108,6 +108,19 @@ describe('extractBouquetAndMix', () => {
 
 		expect(result.hfToken).toBe('hf_request_token');
 	});
+
+	it.each(['bearer', 'BEARER', 'BeArEr'])('should parse the %s authorization scheme case-insensitively', (scheme) => {
+		const result = extractAuthBouquetAndMix({ authorization: `${scheme} hf_request_token` });
+
+		expect(result.hfToken).toBe('hf_request_token');
+	});
+
+	it.each(['Bearer', 'Bearer ', 'Basic hf_request_token', 'Bearer token extra'])(
+		'should ignore malformed authorization value %j',
+		(authorization) => {
+			expect(extractAuthBouquetAndMix({ authorization }).hfToken).toBeUndefined();
+		}
+	);
 });
 
 describe('BOUQUETS configuration', () => {

--- a/packages/app/test/server/utils/tool-selection-strategy.test.ts
+++ b/packages/app/test/server/utils/tool-selection-strategy.test.ts
@@ -521,6 +521,20 @@ describe('ToolSelectionStrategy', () => {
 	});
 
 	describe('User Settings Mode (Third Precedence)', () => {
+		it('accepts the upstream create_repo configuration ID', async () => {
+			const result = await strategy.selectTools({
+				headers: {},
+				userSettings: {
+					builtInTools: ['create_repo'],
+					spaceTools: [],
+				},
+				hfToken: 'test-token',
+			});
+
+			expect(CREATE_REPO_TOOL_ID).toBe('create_repo');
+			expect(result.enabledToolIds).toEqual([CREATE_REPO_TOOL_ID, HF_FS_TOOL_ID]);
+		});
+
 		it('ignores retired and unknown configuration IDs', async () => {
 			const result = await strategy.selectTools({
 				headers: {},

--- a/packages/app/test/server/web-server.test.ts
+++ b/packages/app/test/server/web-server.test.ts
@@ -1,6 +1,8 @@
 import { createServer, type Server } from 'node:http';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { WebServer } from '../../src/server/web-server.js';
+import type { BaseTransport, SessionMetadata } from '../../src/server/transport/base-transport.js';
+import { MetricsCounter } from '../../src/shared/transport-metrics.js';
 
 function listen(server: Server): Promise<void> {
 	return new Promise((resolve, reject) => {
@@ -18,6 +20,15 @@ function close(server: Server): Promise<void> {
 			else resolve();
 		});
 	});
+}
+
+function webServerPort(webServer: WebServer): number {
+	const server = (webServer as unknown as { server: Server | null }).server;
+	const address = server?.address();
+	if (!address || typeof address === 'string') {
+		throw new Error('Expected WebServer to listen on a TCP port');
+	}
+	return address.port;
 }
 
 describe('WebServer', () => {
@@ -47,4 +58,69 @@ describe('WebServer', () => {
 		await expect(webServer.start(address.port)).rejects.toMatchObject({ code: 'EADDRINUSE' });
 		await expect(webServer.start(0)).resolves.toBeUndefined();
 	});
+
+	it('omits analytics session details from stateless transport metrics', async () => {
+		const webServer = new WebServer();
+		webServers.push(webServer);
+		const getSessions = vi.fn(() => [testSession()]);
+		webServer.setTransport(
+			{
+				getMetrics: () => new MetricsCounter().getMetrics(),
+				getSessions,
+			} as unknown as BaseTransport
+		);
+		webServer.setTransportInfo({
+			transport: 'streamableHttpJson',
+			defaultHfTokenSet: false,
+			externalApiMode: false,
+			stdioClient: null,
+		});
+		webServer.setupApiRoutes();
+		await webServer.start(0);
+
+		const response = await fetch(`http://localhost:${webServerPort(webServer).toString()}/api/transport-metrics`);
+		const body = (await response.json()) as { sessions?: unknown[] };
+
+		expect(response.status).toBe(200);
+		expect(body.sessions).toEqual([]);
+		expect(getSessions).not.toHaveBeenCalled();
+	});
+
+	it('retains session details in STDIO transport metrics', async () => {
+		const webServer = new WebServer();
+		webServers.push(webServer);
+		const getSessions = vi.fn(() => [testSession()]);
+		webServer.setTransport(
+			{
+				getMetrics: () => new MetricsCounter().getMetrics(),
+				getSessions,
+			} as unknown as BaseTransport
+		);
+		webServer.setTransportInfo({
+			transport: 'stdio',
+			defaultHfTokenSet: false,
+			externalApiMode: false,
+			stdioClient: null,
+		});
+		webServer.setupApiRoutes();
+		await webServer.start(0);
+
+		const response = await fetch(`http://localhost:${webServerPort(webServer).toString()}/api/transport-metrics`);
+		const body = (await response.json()) as { sessions?: Array<{ id: string }> };
+
+		expect(response.status).toBe(200);
+		expect(body.sessions).toEqual([expect.objectContaining({ id: 'session-1' })]);
+		expect(getSessions).toHaveBeenCalledOnce();
+	});
 });
+
+function testSession(): SessionMetadata {
+	return {
+		id: 'session-1',
+		connectedAt: new Date('2026-07-28T00:00:00.000Z'),
+		lastActivity: new Date(),
+		requestCount: 3,
+		isAuthenticated: false,
+		capabilities: {},
+	};
+}

--- a/packages/app/test/shared/transport-metrics.test.ts
+++ b/packages/app/test/shared/transport-metrics.test.ts
@@ -81,6 +81,36 @@ describe('MetricsCounter', () => {
 		});
 	});
 
+	it('attributes tool calls to the exact protocol used by a client', () => {
+		const metrics = new MetricsCounter();
+		const client = { name: 'mcp', version: '0.1.0' };
+		metrics.associateSessionWithClient(client);
+
+		for (const protocolVersion of ['2025-06-18', '2025-11-25']) {
+			metrics.trackProtocolRequest('legacy', protocolVersion);
+			metrics.trackClientProtocol(client, 'legacy', protocolVersion);
+		}
+		metrics.trackProtocolToolCall('legacy', '2025-11-25', client);
+		metrics.trackProtocolToolCall('legacy', '2025-11-25', client);
+		metrics.trackProtocolToolCall('legacy', '2025-06-18', client);
+
+		const response = formatMetricsForAPI(metrics.getMetrics(), 'streamableHttpJson', true);
+		const protocols = response.clients[0]?.protocols;
+
+		expect(protocols).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ version: '2025-11-25', requestCount: 1, toolCallCount: 2 }),
+				expect.objectContaining({ version: '2025-06-18', requestCount: 1, toolCallCount: 1 }),
+			])
+		);
+		expect(response.protocolVersions).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ version: '2025-11-25', toolCallCount: 2 }),
+				expect.objectContaining({ version: '2025-06-18', toolCallCount: 1 }),
+			])
+		);
+	});
+
 	it('bounds unexpected protocol-version cardinality', () => {
 		const metrics = new MetricsCounter();
 		for (let index = 0; index < 40; index++) {

--- a/packages/mcp/src/create-repo.ts
+++ b/packages/mcp/src/create-repo.ts
@@ -10,7 +10,7 @@ const CREATE_REPO_ACTIONS = ['created', 'duplicated'] as const;
 const DEFAULT_HUB_URL = 'https://huggingface.co';
 
 export const CREATE_REPO_TOOL_CONFIG = {
-	name: 'hf_create_repo',
+	name: 'create_repo',
 	description: '',
 	schema: z.object({
 		uri: z.string().min(1).describe('Destination repo URI in the form hf://models|datasets|spaces|buckets/OWNER/NAME.'),

--- a/packages/mcp/src/tool-ids.test.ts
+++ b/packages/mcp/src/tool-ids.test.ts
@@ -10,6 +10,10 @@ import {
 } from './tool-ids.js';
 
 describe('built-in tool IDs', () => {
+	it('uses the tool ID exposed by the upstream MCP settings API', () => {
+		expect(CREATE_REPO_TOOL_ID).toBe('create_repo');
+	});
+
 	it('contains the supported core tool surface', () => {
 		expect(ALL_BUILTIN_TOOL_IDS).toEqual(
 			expect.arrayContaining([


### PR DESCRIPTION
## Summary

- align the repository-creation tool ID with the upstream MCP settings API by restoring `create_repo`
- stop stateless dashboards from polling and serializing the unbounded analytics-session map; retain detailed sessions for STDIO
- split client rows by exact protocol revision and attribute tool calls to the protocol used for each request
- parse the HTTP `Bearer` authorization scheme case-insensitively while continuing to reject malformed values

## Dashboard behavior

The HTTP dashboard continues to use aggregate session lifecycle counters, but no longer includes individual stateless session records in `/api/transport-metrics` or polls `/api/sessions` outside STDIO mode.

Client rows now represent `(client name, client version, protocol era, protocol version)`. Requests and tool calls are protocol-specific; IP and authentication figures are explicitly labeled as client-wide totals.

## Tests

- `pnpm test` — MCP 295 passed; app 336 passed
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
