### PR TITLE
fix(mcp): align progress handling with modern SDK

### DIFF
--- a/packages/app/src/server/transport/stateless-http-transport.ts
+++ b/packages/app/src/server/transport/stateless-http-transport.ts
@@ -31,6 +31,7 @@ import { RESOURCES_DIRECTORY_READ_METHOD } from '../skills/skill-directory-schem
 import { getProxyToolsConfig } from '../utils/proxy-tools-config.js';
 import { BOUQUET_FALLBACK } from '../../shared/settings.js';
 import { getErrorLogFields } from '../utils/observability.js';
+import { isProgressToken } from '../utils/progress-token.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -197,7 +198,7 @@ export class StatelessHttpTransport extends BaseTransport {
 	private requestsProgress(requestBody: unknown): boolean {
 		const body = requestBody as { method?: unknown; params?: { _meta?: { progressToken?: unknown } } } | undefined;
 		const token = body?.params?._meta?.progressToken;
-		return body?.method === 'tools/call' && (typeof token === 'number' || typeof token === 'string');
+		return body?.method === 'tools/call' && isProgressToken(token);
 	}
 
 	private hasProxyAppResources(): boolean {

--- a/packages/app/src/server/utils/progress-relay.ts
+++ b/packages/app/src/server/utils/progress-relay.ts
@@ -1,5 +1,6 @@
 import type { ServerContext } from '@modelcontextprotocol/server';
 import { logger } from './logger.js';
+import { isProgressToken } from './progress-token.js';
 
 interface ProgressUpdate {
 	progress?: number;
@@ -15,7 +16,7 @@ export function createProgressRelay(extra: ServerContext | undefined): ProgressR
 	}
 
 	const progressToken = extra.mcpReq._meta?.progressToken;
-	if (progressToken === undefined || (typeof progressToken !== 'number' && typeof progressToken !== 'string')) {
+	if (!isProgressToken(progressToken)) {
 		return undefined;
 	}
 

--- a/packages/app/src/server/utils/progress-token.ts
+++ b/packages/app/src/server/utils/progress-token.ts
@@ -1,0 +1,3 @@
+export function isProgressToken(value: unknown): value is string | number {
+	return typeof value === 'string' || (typeof value === 'number' && Number.isInteger(value));
+}

--- a/packages/app/src/server/utils/streamable-http-tool-caller.ts
+++ b/packages/app/src/server/utils/streamable-http-tool-caller.ts
@@ -64,7 +64,6 @@ export async function callStreamableHttpTool(
 	logger.trace({ serverUrl }, 'Streamable proxy connected upstream');
 
 	try {
-		const progressToken = 'hf-mcp-server';
 		const requestOptions: RequestOptions = {
 			onprogress: (progress) => {
 				logger.trace({ serverUrl, toolName, progress }, 'Streamable proxy upstream progress event');
@@ -83,7 +82,6 @@ export async function callStreamableHttpTool(
 				params: {
 					name: toolName,
 					arguments: parameters,
-					_meta: { progressToken },
 				},
 			},
 			requestOptions

--- a/packages/app/test/server/transport/stateless-http-transport.test.ts
+++ b/packages/app/test/server/transport/stateless-http-transport.test.ts
@@ -85,6 +85,38 @@ describe('StatelessHttpTransport', () => {
 		}
 	});
 
+	describe('requestsProgress', () => {
+		it.each(['progress-token', 42])('accepts valid progress token %j', (progressToken) => {
+			expect(
+				(transport as any).requestsProgress({
+					method: 'tools/call',
+					params: { _meta: { progressToken } },
+				})
+			).toBe(true);
+		});
+
+		it.each([undefined, null, true, 1.5, Number.NaN, Number.POSITIVE_INFINITY, {}, []])(
+			'rejects missing or invalid progress token %j',
+			(progressToken) => {
+				expect(
+					(transport as any).requestsProgress({
+						method: 'tools/call',
+						params: { _meta: { progressToken } },
+					})
+				).toBe(false);
+			}
+		);
+
+		it('only enables progress streaming for tool calls', () => {
+			expect(
+				(transport as any).requestsProgress({
+					method: 'resources/read',
+					params: { _meta: { progressToken: 'progress-token' } },
+				})
+			).toBe(false);
+		});
+	});
+
 	describe('shouldHandle', () => {
 		it('should handle tools/list requests', () => {
 			const result = (transport as any).shouldHandle({ method: 'tools/list' });

--- a/packages/app/test/server/utils/progress-relay.test.ts
+++ b/packages/app/test/server/utils/progress-relay.test.ts
@@ -39,10 +39,13 @@ describe('createProgressRelay', () => {
 		});
 	});
 
-	it.each([undefined, null, true, {}, []])('ignores missing or invalid token %j', (progressToken) => {
-		const extra = progressToken === undefined ? undefined : makeExtra(progressToken).extra;
-		expect(createProgressRelay(extra)).toBeUndefined();
-	});
+	it.each([undefined, null, true, 1.5, Number.NaN, Number.POSITIVE_INFINITY, {}, []])(
+		'ignores missing or invalid token %j',
+		(progressToken) => {
+			const extra = progressToken === undefined ? undefined : makeExtra(progressToken).extra;
+			expect(createProgressRelay(extra)).toBeUndefined();
+		}
+	);
 
 	it('uses a monotonically increasing fallback when progress is omitted', async () => {
 		const { extra, sendNotification } = makeExtra('token');

--- a/packages/app/test/server/utils/streamable-http-tool-caller.test.ts
+++ b/packages/app/test/server/utils/streamable-http-tool-caller.test.ts
@@ -49,7 +49,6 @@ describe('callStreamableHttpTool', () => {
 				params: {
 					name: 'csv_tool',
 					arguments: {},
-					_meta: { progressToken: 'hf-mcp-server' },
 				},
 			},
 			expect.objectContaining({

--- a/packages/mcp/src/sandbox-tool.ts
+++ b/packages/mcp/src/sandbox-tool.ts
@@ -1049,7 +1049,7 @@ export class HfSandboxTool extends SandboxToolBase {
 			attempt += 1;
 			await notifySandboxProgress(options, {
 				event: 'create',
-				message: `Creating sandbox ${name}: checking startup health (attempt ${String(attempt)}).`,
+				message: `Creating sandbox ${name}: (step ${String(attempt)}).`,
 			});
 			try {
 				const health = normalizeSandboxHealth(

--- a/packages/mcp/src/space/utils/gradio-caller.ts
+++ b/packages/mcp/src/space/utils/gradio-caller.ts
@@ -240,7 +240,6 @@ export async function callGradioToolWithHeaders(
 	logger.trace('[gradio] connected streamable client', { mcpUrl: validatedMcpUrl.toString() });
 
 	try {
-		const progressToken = 'hf-mcp-server';
 		const requestOptions: RequestOptions = {
 			onprogress: (progress) => {
 				logger.trace('[gradio] upstream progress event', { toolName, progress });
@@ -259,7 +258,6 @@ export async function callGradioToolWithHeaders(
 				params: {
 					name: toolName,
 					arguments: parameters,
-					_meta: { progressToken },
 				},
 			},
 			requestOptions

--- a/packages/mcp/test/gradio-caller-progress.test.ts
+++ b/packages/mcp/test/gradio-caller-progress.test.ts
@@ -55,7 +55,6 @@ describe('callGradioToolWithHeaders progress handling', () => {
 				params: {
 					name: 'predict',
 					arguments: {},
-					_meta: { progressToken: 'hf-mcp-server' },
 				},
 			},
 			expect.objectContaining({

--- a/packages/mcp/test/sandbox-tool.spec.ts
+++ b/packages/mcp/test/sandbox-tool.spec.ts
@@ -218,7 +218,7 @@ describe('HfSandboxTool', () => {
 		expect(onProgress).toHaveBeenCalledWith(
 			expect.objectContaining({
 				event: 'create',
-				message: expect.stringMatching(/checking startup health \(attempt 1\)/),
+				message: expect.stringMatching(/\(step 1\)/),
 			})
 		);
 		expect(onProgress).toHaveBeenCalledWith(


### PR DESCRIPTION
## Summary
- align progress-token validation with the modern SDK’s string-or-integer contract
- let modern MCP clients allocate upstream progress tokens for Streamable HTTP and Gradio calls
- reject `subscriptions/listen` with a completed JSON-RPC error instead of retaining an SSE stream
- update Sandbox startup progress wording and its assertion

## Validation
- `pnpm lint`
- `pnpm build`
- `pnpm -C packages/app test` (350 passed before the listen regression test was added)
- `pnpm -C packages/mcp test` (295 passed)
- `pnpm -C packages/app exec vitest run test/server/transport/stateless-http-transport.test.ts` (39 passed)
- `pnpm -C packages/app typecheck`
- `pnpm -C packages/app lint:check`