### PR TITLE
revert: preserve modern subscription listen semantics

### DIFF
--- a/packages/app/src/server/transport/stateless-http-transport.ts
+++ b/packages/app/src/server/transport/stateless-http-transport.ts
@@ -44,9 +44,9 @@ const RESOURCE_METHODS = new Set([
 	RESOURCES_DIRECTORY_READ_METHOD,
 ]);
 const FULL_SERVER_METHODS = new Set(['tools/list', 'tools/call', 'initialize', ...RESOURCE_METHODS]);
-// Subscription methods we never support (skills are static and this stateless
-// server must not retain long-lived listen streams). Rejected before any server is built.
-const UNSUPPORTED_SUBSCRIBE_METHODS = new Set(['resources/subscribe', 'resources/unsubscribe', 'subscriptions/listen']);
+// Resource-subscription methods we never support (skills are static — nothing to
+// notify `resources/updated` about). Rejected cheaply before any server is built.
+const UNSUPPORTED_SUBSCRIBE_METHODS = new Set(['resources/subscribe', 'resources/unsubscribe']);
 const UNSUPPORTED_PROMPT_METHODS = new Set(['prompts/list', 'prompts/get']);
 export const MAX_METRICS_RESPONSE_CAPTURE_BYTES = 64 * 1024;
 
@@ -544,17 +544,12 @@ export class StatelessHttpTransport extends BaseTransport {
 		}) as typeof res.end;
 
 		try {
-			const rpcMethod = requestBody?.method;
-			if (rpcMethod && UNSUPPORTED_SUBSCRIBE_METHODS.has(rpcMethod)) {
-				res.status(200).json(JsonRpcErrors.methodNotFound(extractJsonRpcId(req.body), `${rpcMethod} is not supported`));
-			} else {
-				if (!this.modernNodeHandler) {
-					throw new Error('Modern MCP handler is not initialized');
-				}
-				await this.modernRequestStorage.run(requestData, async () => {
-					await this.modernNodeHandler?.(req, res, req.body);
-				});
+			if (!this.modernNodeHandler) {
+				throw new Error('Modern MCP handler is not initialized');
 			}
+			await this.modernRequestStorage.run(requestData, async () => {
+				await this.modernNodeHandler?.(req, res, req.body);
+			});
 
 			const responseIsError = res.statusCode >= 400 || responseCapture.isError();
 			this.trackMethodCall(trackingName, startTime, responseIsError, clientInfo);

--- a/packages/app/test/server/transport/stateless-http-transport.test.ts
+++ b/packages/app/test/server/transport/stateless-http-transport.test.ts
@@ -294,53 +294,6 @@ describe('StatelessHttpTransport', () => {
 	});
 
 	describe('production request path', () => {
-		it('rejects modern subscription listeners instead of opening a persistent stream', async () => {
-			const app = express();
-			app.use(express.json());
-			const serverFactory: ServerFactory = vi.fn(async () => ({
-				server: new McpServer({ name: 'modern-subscription-test', version: '1.0.0' }),
-				enabledToolIds: [],
-			}));
-			transport = new StatelessHttpTransport(serverFactory, app);
-			await transport.initialize();
-
-			const httpServer = app.listen(0);
-			try {
-				await new Promise<void>((resolve, reject) => {
-					httpServer.once('listening', resolve);
-					httpServer.once('error', reject);
-				});
-				const address = httpServer.address();
-				if (!address || typeof address === 'string') {
-					throw new Error('Expected the test server to listen on a TCP port');
-				}
-
-				const client = new Client(
-					{ name: 'modern-subscription-test', version: '1.0.0' },
-					{ versionNegotiation: { mode: { pin: '2026-07-28' } } }
-				);
-				const clientTransport = new StreamableHTTPClientTransport(new URL(`http://127.0.0.1:${address.port}/mcp`));
-				await client.connect(clientTransport);
-				const factoryCallsBeforeListen = vi.mocked(serverFactory).mock.calls.length;
-
-				await expect(client.listen({})).rejects.toThrow('subscriptions/listen is not supported');
-
-				expect(vi.mocked(serverFactory).mock.calls).toHaveLength(factoryCallsBeforeListen);
-				expect(transport.getMetrics().methods.get('subscriptions/listen')).toMatchObject({ count: 1, errors: 1 });
-				expect(
-					Array.from(transport.getMetrics().clients.values()).find(
-						(candidate) => candidate.name === 'modern-subscription-test'
-					)
-				).toMatchObject({ isConnected: false, activeConnections: 0 });
-				await client.close();
-			} finally {
-				await new Promise<void>((resolve, reject) => {
-					httpServer.close((error) => (error ? reject(error) : resolve()));
-				});
-				await transport.cleanup();
-			}
-		});
-
 		it('serves modern clients request-scoped with discovery, identity metrics, and streamed progress', async () => {
 			process.env.ANALYTICS_MODE = 'true';
 			const app = express();


### PR DESCRIPTION
## Summary
- revert #212
- `subscriptions/listen` is a core 2026-07-28 subscription stream, even when the honored notification filter is empty
- rejecting it as method-not-found is not semantically compliant with the negotiated modern protocol

The SDK correctly acknowledges the supported subset (possibly `{}`) and retains the request-scoped stream until cancellation or server closure.