### PR TITLE
fix(app): refuse subscription streams via SDK limit

### DIFF
--- a/packages/app/src/server/transport/stateless-http-transport.ts
+++ b/packages/app/src/server/transport/stateless-http-transport.ts
@@ -44,9 +44,9 @@ const RESOURCE_METHODS = new Set([
 	RESOURCES_DIRECTORY_READ_METHOD,
 ]);
 const FULL_SERVER_METHODS = new Set(['tools/list', 'tools/call', 'initialize', ...RESOURCE_METHODS]);
-// Subscription methods we never support (skills are static and this stateless
-// server must not retain long-lived listen streams). Rejected before any server is built.
-const UNSUPPORTED_SUBSCRIBE_METHODS = new Set(['resources/subscribe', 'resources/unsubscribe', 'subscriptions/listen']);
+// Resource-subscription methods we never support (skills are static — nothing to
+// notify `resources/updated` about). Rejected cheaply before any server is built.
+const UNSUPPORTED_SUBSCRIBE_METHODS = new Set(['resources/subscribe', 'resources/unsubscribe']);
 const UNSUPPORTED_PROMPT_METHODS = new Set(['prompts/list', 'prompts/get']);
 export const MAX_METRICS_RESPONSE_CAPTURE_BYTES = 64 * 1024;
 
@@ -384,6 +384,9 @@ export class StatelessHttpTransport extends BaseTransport {
 			{
 				legacy: 'reject',
 				responseMode: 'auto',
+				// This deployment does not publish subscription notifications, so
+				// refuse listen streams through the SDK's pre-ack capacity guard.
+				maxSubscriptions: 0,
 				onerror: (error) => {
 					const requestData = this.modernRequestStorage.getStore();
 					logger.error(
@@ -544,17 +547,12 @@ export class StatelessHttpTransport extends BaseTransport {
 		}) as typeof res.end;
 
 		try {
-			const rpcMethod = requestBody?.method;
-			if (rpcMethod && UNSUPPORTED_SUBSCRIBE_METHODS.has(rpcMethod)) {
-				res.status(200).json(JsonRpcErrors.methodNotFound(extractJsonRpcId(req.body), `${rpcMethod} is not supported`));
-			} else {
-				if (!this.modernNodeHandler) {
-					throw new Error('Modern MCP handler is not initialized');
-				}
-				await this.modernRequestStorage.run(requestData, async () => {
-					await this.modernNodeHandler?.(req, res, req.body);
-				});
+			if (!this.modernNodeHandler) {
+				throw new Error('Modern MCP handler is not initialized');
 			}
+			await this.modernRequestStorage.run(requestData, async () => {
+				await this.modernNodeHandler?.(req, res, req.body);
+			});
 
 			const responseIsError = res.statusCode >= 400 || responseCapture.isError();
 			this.trackMethodCall(trackingName, startTime, responseIsError, clientInfo);

--- a/packages/app/test/server/transport/stateless-http-transport.test.ts
+++ b/packages/app/test/server/transport/stateless-http-transport.test.ts
@@ -294,7 +294,7 @@ describe('StatelessHttpTransport', () => {
 	});
 
 	describe('production request path', () => {
-		it('rejects modern subscription listeners instead of opening a persistent stream', async () => {
+		it('rejects modern subscription listeners through the configured SDK limit', async () => {
 			const app = express();
 			app.use(express.json());
 			const serverFactory: ServerFactory = vi.fn(async () => ({
@@ -323,7 +323,7 @@ describe('StatelessHttpTransport', () => {
 				await client.connect(clientTransport);
 				const factoryCallsBeforeListen = vi.mocked(serverFactory).mock.calls.length;
 
-				await expect(client.listen({})).rejects.toThrow('subscriptions/listen is not supported');
+				await expect(client.listen({})).rejects.toThrow('Subscription limit reached');
 
 				expect(vi.mocked(serverFactory).mock.calls).toHaveLength(factoryCallsBeforeListen);
 				expect(transport.getMetrics().methods.get('subscriptions/listen')).toMatchObject({ count: 1, errors: 1 });


### PR DESCRIPTION
## Summary
- replace the custom `subscriptions/listen` method-not-found interception with the SDK-supported `maxSubscriptions: 0` policy
- let the modern SDK validate and recognize listen requests before refusing them through its pre-ack capacity guard
- keep legacy resource subscription rejection unchanged
- assert the modern client receives `Subscription limit reached` without opening a persistent SSE stream

## Rationale
The modern spec and TypeScript SDK model zero advertised notification capabilities as an empty acknowledged filter. This deployment does not retain subscription streams, so a zero SDK subscription capacity expresses that operational policy without treating the core method as unknown.

## Validation
- app transport test: 39 passed
- app tests: 354 passed
- app typecheck: passed
- app lint: passed