### PR TITLE
feat(app): instrument subscription attempts

### DIFF
--- a/packages/app/src/server/transport/stateless-http-transport.ts
+++ b/packages/app/src/server/transport/stateless-http-transport.ts
@@ -32,6 +32,7 @@ import { getProxyToolsConfig } from '../utils/proxy-tools-config.js';
 import { BOUQUET_FALLBACK } from '../../shared/settings.js';
 import { getErrorLogFields } from '../utils/observability.js';
 import { isProgressToken } from '../utils/progress-token.js';
+import type { SubscriptionMethod } from '../../shared/transport-metrics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -60,6 +61,7 @@ interface JsonRpcRequestBody {
 		capabilities?: unknown;
 		protocolVersion?: unknown;
 		name?: string;
+		notifications?: unknown;
 		_meta?: Record<string, unknown>;
 	};
 }
@@ -76,6 +78,60 @@ interface ModernRequestData {
 	protocolVersion: string;
 	clientCapabilities: Record<string, unknown>;
 	userHash?: string;
+}
+
+const SUBSCRIPTION_BOOLEAN_FILTER_FIELDS = ['toolsListChanged', 'promptsListChanged', 'resourcesListChanged'] as const;
+const SUBSCRIPTION_FILTER_FIELDS = new Set<string>([...SUBSCRIPTION_BOOLEAN_FILTER_FIELDS, 'resourceSubscriptions']);
+
+function resourceSubscriptionCountBucket(length: number): string {
+	if (length === 0) return '0';
+	if (length === 1) return '1';
+	if (length <= 10) return '2-10';
+	if (length <= 100) return '11-100';
+	return '101+';
+}
+
+/**
+ * Produce a low-cardinality summary of subscription intent. In particular,
+ * never retain resource URIs from the modern listen filter.
+ */
+export function summarizeSubscriptionRequest(method: SubscriptionMethod, params: unknown): string {
+	if (method !== 'subscriptions/listen') {
+		if (typeof params !== 'object' || params === null || Array.isArray(params) || !('uri' in params)) {
+			return 'uri:missing';
+		}
+		return typeof params.uri === 'string' ? 'uri:present' : 'uri:invalid';
+	}
+
+	if (typeof params !== 'object' || params === null || Array.isArray(params) || !('notifications' in params)) {
+		return 'notifications:missing';
+	}
+	const notifications = params.notifications;
+	if (typeof notifications !== 'object' || notifications === null || Array.isArray(notifications)) {
+		return 'notifications:invalid';
+	}
+
+	const parts: string[] = [];
+	for (const field of SUBSCRIPTION_BOOLEAN_FILTER_FIELDS) {
+		if (!(field in notifications)) continue;
+		const value = notifications[field];
+		parts.push(`${field}:${typeof value === 'boolean' ? String(value) : 'invalid'}`);
+	}
+
+	if ('resourceSubscriptions' in notifications) {
+		const subscriptions = notifications.resourceSubscriptions;
+		if (Array.isArray(subscriptions) && subscriptions.every((uri) => typeof uri === 'string')) {
+			parts.push(`resourceSubscriptions:${resourceSubscriptionCountBucket(subscriptions.length)}`);
+		} else {
+			parts.push('resourceSubscriptions:invalid');
+		}
+	}
+
+	if (Object.keys(notifications).some((field) => !SUBSCRIPTION_FILTER_FIELDS.has(field))) {
+		parts.push('unknownFields:present');
+	}
+
+	return parts.length > 0 ? `notifications:${parts.join(',')}` : 'notifications:empty';
 }
 
 function isErrorResponseBody(body: string): boolean {
@@ -159,6 +215,23 @@ export class StatelessHttpTransport extends BaseTransport {
 	private readonly modernRequestStorage = new AsyncLocalStorage<ModernRequestData>();
 	private modernHandler?: McpHttpHandler;
 	private modernNodeHandler?: ReturnType<typeof toNodeHandler>;
+
+	private trackSubscriptionAttempt(
+		method: SubscriptionMethod,
+		protocolEra: 'legacy' | 'modern',
+		protocolVersion: string,
+		params: unknown,
+		clientInfo?: { name: string; version: string }
+	): void {
+		this.metrics.trackSubscriptionAttempt({
+			method,
+			protocolEra,
+			protocolVersion,
+			clientName: clientInfo?.name,
+			clientVersion: clientInfo?.version,
+			requestShape: summarizeSubscriptionRequest(method, params),
+		});
+	}
 
 	constructor(serverFactory: ServerFactory, app: Express) {
 		super(serverFactory, app);
@@ -476,6 +549,9 @@ export class StatelessHttpTransport extends BaseTransport {
 
 		this.trackIpAddress(ipAddress);
 		this.trackProtocolRequest('modern', protocolVersion);
+		if (requestBody?.method === 'subscriptions/listen') {
+			this.trackSubscriptionAttempt('subscriptions/listen', 'modern', protocolVersion, requestBody.params, clientInfo);
+		}
 
 		const authResult = await this.validateAuthAndTrackMetrics(headers);
 		if (!authResult.shouldContinue) {
@@ -629,6 +705,13 @@ export class StatelessHttpTransport extends BaseTransport {
 				this.extractClientInfoFromRequest(requestBody) ??
 				(typeof earlySessionId === 'string' ? this.analyticsSessions.get(earlySessionId)?.clientInfo : undefined);
 
+			this.trackSubscriptionAttempt(
+				rpcMethod as 'resources/subscribe' | 'resources/unsubscribe',
+				'legacy',
+				protocolVersion,
+				requestBody?.params,
+				earlyClientInfo
+			);
 			this.trackMethodCall(trackingName, startTime, true, earlyClientInfo);
 			res.status(200).json(JsonRpcErrors.methodNotFound(extractJsonRpcId(req.body), `${rpcMethod} is not supported`));
 			return;

--- a/packages/app/src/server/transport/stateless-http-transport.ts
+++ b/packages/app/src/server/transport/stateless-http-transport.ts
@@ -106,10 +106,11 @@ export function summarizeSubscriptionRequest(method: SubscriptionMethod, params:
 	if (typeof params !== 'object' || params === null || Array.isArray(params) || !('notifications' in params)) {
 		return 'notifications:missing';
 	}
-	const notifications = params.notifications;
-	if (typeof notifications !== 'object' || notifications === null || Array.isArray(notifications)) {
+	const notificationValue = params.notifications;
+	if (typeof notificationValue !== 'object' || notificationValue === null || Array.isArray(notificationValue)) {
 		return 'notifications:invalid';
 	}
+	const notifications = notificationValue as Record<string, unknown>;
 
 	const parts: string[] = [];
 	for (const field of SUBSCRIPTION_BOOLEAN_FILTER_FIELDS) {

--- a/packages/app/src/shared/transport-metrics.ts
+++ b/packages/app/src/shared/transport-metrics.ts
@@ -2,6 +2,22 @@ import { createHash } from 'node:crypto';
 import type { TransportType } from './constants.js';
 
 export type ProtocolEra = 'legacy' | 'modern';
+export type SubscriptionMethod = 'resources/subscribe' | 'resources/unsubscribe' | 'subscriptions/listen';
+
+export interface SubscriptionAttempt {
+	method: SubscriptionMethod;
+	protocolEra: ProtocolEra;
+	protocolVersion: string;
+	clientName?: string;
+	clientVersion?: string;
+	requestShape: string;
+}
+
+interface SubscriptionAttemptMetrics extends SubscriptionAttempt {
+	count: number;
+	firstSeen: Date;
+	lastSeen: Date;
+}
 
 interface ProtocolUsageMetrics {
 	era: ProtocolEra;
@@ -76,6 +92,10 @@ export interface TransportMetrics {
 
 	// Method metrics
 	methods: Map<string, MethodMetrics>;
+
+	// Legacy resource-subscription and modern subscription-stream attempts.
+	// Request shapes are sanitized before reaching this metrics layer.
+	subscriptionAttempts: Map<string, SubscriptionAttemptMetrics>;
 
 	// Static page hits (for stateless transport)
 	staticPageHits200?: number;
@@ -168,6 +188,13 @@ const MAX_DISTINCT_METHOD_DETAILS = 500;
 const UNEXPECTED_METHOD_DETAIL = '__unexpected__';
 const MAX_DISTINCT_PROTOCOL_VERSIONS = 32;
 const UNEXPECTED_PROTOCOL_VERSION = '__other__';
+const MAX_DISTINCT_SUBSCRIPTION_ATTEMPTS = 500;
+const UNEXPECTED_SUBSCRIPTION_DIMENSION = '__other__';
+const MAX_SUBSCRIPTION_DIMENSION_LENGTH = 120;
+
+function boundSubscriptionDimension(value: unknown): string | undefined {
+	return typeof value === 'string' ? value.slice(0, MAX_SUBSCRIPTION_DIMENSION_LENGTH) : undefined;
+}
 
 /**
  * API response format for transport metrics
@@ -290,6 +317,18 @@ export interface TransportMetricsResponse {
 		}>;
 	}>;
 
+	subscriptionAttempts: Array<{
+		method: SubscriptionMethod;
+		protocolEra: ProtocolEra;
+		protocolVersion: string;
+		clientName?: string;
+		clientVersion?: string;
+		requestShape: string;
+		count: number;
+		firstSeen: string;
+		lastSeen: string;
+	}>;
+
 	// API call metrics (only shown in external API mode)
 	apiMetrics?: ApiCallMetrics;
 
@@ -363,6 +402,13 @@ export function formatMetricsForAPI(
 				count: client.count,
 			})),
 		})),
+		subscriptionAttempts: Array.from(metrics.subscriptionAttempts.values())
+			.map((attempt) => ({
+				...attempt,
+				firstSeen: attempt.firstSeen.toISOString(),
+				lastSeen: attempt.lastSeen.toISOString(),
+			}))
+			.sort((a, b) => b.count - a.count),
 	};
 }
 
@@ -409,6 +455,7 @@ function createEmptyMetrics(): TransportMetrics {
 		},
 		clients: new Map(),
 		methods: new Map(),
+		subscriptionAttempts: new Map(),
 		staticPageHits200: 0,
 		staticPageHits405: 0,
 	};
@@ -616,11 +663,7 @@ export class MetricsCounter {
 	/**
 	 * Attribute a tool call to the exact protocol revision used for the request.
 	 */
-	trackProtocolToolCall(
-		era: ProtocolEra,
-		version: string,
-		clientInfo?: { name: string; version: string }
-	): void {
+	trackProtocolToolCall(era: ProtocolEra, version: string, clientInfo?: { name: string; version: string }): void {
 		const normalizedVersion = this.normalizeProtocolVersion(era, version);
 		const protocolKey = getProtocolKey(era, normalizedVersion);
 		const aggregate = this.metrics.protocolVersions.get(protocolKey);
@@ -929,6 +972,69 @@ export class MetricsCounter {
 				methodMetrics.averageResponseTime = totalTime / successfulCalls;
 			}
 		}
+	}
+
+	/**
+	 * Track subscription intent without retaining resource URIs or other
+	 * caller-controlled filter values.
+	 */
+	trackSubscriptionAttempt(attempt: SubscriptionAttempt): void {
+		const boundedProtocolVersion =
+			boundSubscriptionDimension(attempt.protocolVersion) ?? UNEXPECTED_SUBSCRIPTION_DIMENSION;
+		const normalizedAttempt = {
+			...attempt,
+			protocolVersion: this.normalizeProtocolVersion(attempt.protocolEra, boundedProtocolVersion),
+			clientName: boundSubscriptionDimension(attempt.clientName),
+			clientVersion: boundSubscriptionDimension(attempt.clientVersion),
+			requestShape: boundSubscriptionDimension(attempt.requestShape) ?? UNEXPECTED_SUBSCRIPTION_DIMENSION,
+		};
+		let key = JSON.stringify([
+			normalizedAttempt.method,
+			normalizedAttempt.protocolEra,
+			normalizedAttempt.protocolVersion,
+			normalizedAttempt.clientName,
+			normalizedAttempt.clientVersion,
+			normalizedAttempt.requestShape,
+		]);
+		let existing = this.metrics.subscriptionAttempts.get(key);
+
+		if (!existing && this.metrics.subscriptionAttempts.size >= MAX_DISTINCT_SUBSCRIPTION_ATTEMPTS) {
+			const overflowAttempt: SubscriptionAttempt = {
+				method: normalizedAttempt.method,
+				protocolEra: normalizedAttempt.protocolEra,
+				protocolVersion: UNEXPECTED_SUBSCRIPTION_DIMENSION,
+				requestShape: UNEXPECTED_SUBSCRIPTION_DIMENSION,
+			};
+			key = JSON.stringify([
+				overflowAttempt.method,
+				overflowAttempt.protocolEra,
+				overflowAttempt.protocolVersion,
+				overflowAttempt.requestShape,
+			]);
+			existing = this.metrics.subscriptionAttempts.get(key);
+			if (!existing) {
+				this.metrics.subscriptionAttempts.set(key, {
+					...overflowAttempt,
+					count: 1,
+					firstSeen: new Date(),
+					lastSeen: new Date(),
+				});
+				return;
+			}
+		}
+
+		if (existing) {
+			existing.count++;
+			existing.lastSeen = new Date();
+			return;
+		}
+
+		this.metrics.subscriptionAttempts.set(key, {
+			...normalizedAttempt,
+			count: 1,
+			firstSeen: new Date(),
+			lastSeen: new Date(),
+		});
 	}
 
 	private normalizeMethodName(method: string): string {

--- a/packages/app/src/web/components/ProtocolMetricsCard.tsx
+++ b/packages/app/src/web/components/ProtocolMetricsCard.tsx
@@ -1,4 +1,5 @@
 import useSWR from 'swr';
+import type { ColumnDef } from '@tanstack/react-table';
 import { Badge } from './ui/badge';
 import { Card, CardContent } from './ui/card';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from './ui/table';
@@ -6,6 +7,8 @@ import type { TransportMetricsResponse } from '../../shared/transport-metrics.js
 import { ArrowRight, Network, Radio, Users, Waypoints } from 'lucide-react';
 import { MetricTile, SectionHeader } from './DashboardPrimitives';
 import { formatCompactNumber } from '../lib/dashboard-utils';
+import { DataTable } from './data-table';
+import { createSortableHeader } from './data-table-utils';
 
 const fetcher = (url: string) =>
 	fetch(url).then((response) => {
@@ -41,6 +44,69 @@ function formatProtocolShare(requestCount: number, totalRequests: number): strin
 	return `${Math.round(share).toString()}%`;
 }
 
+type SubscriptionAttempt = TransportMetricsResponse['subscriptionAttempts'][number];
+type SubscriptionAttemptRow = SubscriptionAttempt & {
+	client: string;
+	protocol: string;
+};
+
+const subscriptionAttemptColumns: ColumnDef<SubscriptionAttemptRow>[] = [
+	{
+		accessorKey: 'method',
+		header: createSortableHeader('Method'),
+		cell: ({ row }) => <span className="font-mono text-xs">{row.original.method}</span>,
+	},
+	{
+		accessorKey: 'client',
+		header: createSortableHeader('Client'),
+		cell: ({ row }) =>
+			row.original.clientName ? (
+				<span className="font-mono text-xs">{row.original.client}</span>
+			) : (
+				<span className="text-sm text-muted-foreground">Unattributed</span>
+			),
+	},
+	{
+		accessorKey: 'protocol',
+		header: createSortableHeader('Protocol'),
+		cell: ({ row }) => (
+			<div className="flex items-center gap-2">
+				<Badge variant={row.original.protocolEra === 'modern' ? 'success' : 'secondary'}>
+					{row.original.protocolEra}
+				</Badge>
+				<span className="font-mono text-xs">{row.original.protocolVersion}</span>
+			</div>
+		),
+	},
+	{
+		accessorKey: 'requestShape',
+		header: createSortableHeader('Requested behavior'),
+		cell: ({ row }) => (
+			<span
+				className="block w-72 whitespace-normal break-words font-mono text-xs lg:w-96"
+				title={row.original.requestShape}
+			>
+				{row.original.requestShape}
+			</span>
+		),
+	},
+	{
+		accessorKey: 'count',
+		header: createSortableHeader('Attempts', 'right'),
+		cell: ({ row }) => <div className="text-right font-mono">{row.original.count.toLocaleString()}</div>,
+	},
+	{
+		accessorKey: 'firstSeen',
+		header: createSortableHeader('First seen'),
+		cell: ({ row }) => <span className="text-xs">{new Date(row.original.firstSeen).toLocaleString()}</span>,
+	},
+	{
+		accessorKey: 'lastSeen',
+		header: createSortableHeader('Last seen'),
+		cell: ({ row }) => <span className="text-xs">{new Date(row.original.lastSeen).toLocaleString()}</span>,
+	},
+];
+
 export function ProtocolMetricsCard() {
 	const { data: metrics, error } = useSWR<TransportMetricsResponse>('/api/transport-metrics', fetcher, {
 		refreshInterval: 3000,
@@ -66,6 +132,25 @@ export function ProtocolMetricsCard() {
 			client.protocols.some((protocol) => protocol.era === 'modern') &&
 			client.protocols.some((protocol) => protocol.era === 'legacy')
 	).length;
+	const subscriptionAttempts = metrics.subscriptionAttempts ?? [];
+	const subscriptionAttemptRows: SubscriptionAttemptRow[] = subscriptionAttempts.map((attempt) => ({
+		...attempt,
+		client: attempt.clientName ? `${attempt.clientName}@${attempt.clientVersion ?? 'unknown'}` : 'Unattributed',
+		protocol: `${attempt.protocolEra}:${attempt.protocolVersion}`,
+	}));
+	const subscriptionAttemptTotal = subscriptionAttempts.reduce((sum, attempt) => sum + attempt.count, 0);
+	const modernSubscriptionAttemptTotal = subscriptionAttempts
+		.filter((attempt) => attempt.method === 'subscriptions/listen')
+		.reduce((sum, attempt) => sum + attempt.count, 0);
+	const legacySubscriptionAttemptTotal = subscriptionAttemptTotal - modernSubscriptionAttemptTotal;
+	const subscriptionClientCount = new Set(
+		subscriptionAttempts
+			.filter((attempt) => attempt.clientName)
+			.map((attempt) => `${attempt.clientName}:${attempt.clientVersion ?? 'unknown'}`)
+	).size;
+	const subscriptionBehaviorCount = new Set(
+		subscriptionAttempts.map((attempt) => `${attempt.method}:${attempt.requestShape}`)
+	).size;
 
 	return (
 		<div className="space-y-5">
@@ -201,6 +286,81 @@ export function ProtocolMetricsCard() {
 							</>
 						)}
 					</div>
+				</CardContent>
+			</Card>
+
+			<Card>
+				<CardContent className="space-y-5">
+					<SectionHeader
+						title="Subscription behavior"
+						description="Incoming legacy resource subscriptions and modern listen filters since this process started. This deployment currently rejects every attempt."
+						aside={
+							<Badge
+								variant="outline"
+								className={
+									subscriptionAttemptTotal > 0
+										? 'border-amber-300 bg-amber-50 text-amber-800 dark:border-amber-900 dark:bg-amber-950/35 dark:text-amber-200'
+										: undefined
+								}
+							>
+								{formatCompactNumber(subscriptionAttemptTotal)} attempts
+							</Badge>
+						}
+					/>
+					<div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+						<div className="rounded-xl border bg-muted/25 p-3">
+							<p className="text-xs font-medium text-muted-foreground">Modern listen attempts</p>
+							<p className="mt-1 font-mono text-xl font-semibold">
+								{formatCompactNumber(modernSubscriptionAttemptTotal)}
+							</p>
+						</div>
+						<div className="rounded-xl border bg-muted/25 p-3">
+							<p className="text-xs font-medium text-muted-foreground">Legacy subscription attempts</p>
+							<p className="mt-1 font-mono text-xl font-semibold">
+								{formatCompactNumber(legacySubscriptionAttemptTotal)}
+							</p>
+						</div>
+						<div className="rounded-xl border bg-muted/25 p-3">
+							<p className="text-xs font-medium text-muted-foreground">Attributed clients</p>
+							<p className="mt-1 font-mono text-xl font-semibold">{subscriptionClientCount}</p>
+						</div>
+						<div className="rounded-xl border bg-muted/25 p-3">
+							<p className="text-xs font-medium text-muted-foreground">Observed behaviors</p>
+							<p className="mt-1 font-mono text-xl font-semibold">{subscriptionBehaviorCount}</p>
+						</div>
+					</div>
+					{subscriptionAttemptRows.length === 0 ? (
+						<div className="flex h-24 items-center justify-center rounded-xl border border-dashed text-sm text-muted-foreground">
+							Subscription behavior will appear after the first subscribe or listen attempt.
+						</div>
+					) : (
+						<DataTable
+							columns={subscriptionAttemptColumns}
+							data={subscriptionAttemptRows}
+							searchColumn="client"
+							searchPlaceholder="Filter subscription clients..."
+							facetFilter={{
+								column: 'method',
+								label: 'All subscription methods',
+								options: [
+									{ label: 'Modern listen attempts', value: 'subscriptions/listen' },
+									{ label: 'Legacy subscribe', value: 'resources/subscribe' },
+									{ label: 'Legacy unsubscribe', value: 'resources/unsubscribe' },
+								],
+							}}
+							pageSize={25}
+							defaultColumnVisibility={{
+								method: true,
+								client: true,
+								protocol: true,
+								requestShape: true,
+								count: true,
+								firstSeen: false,
+								lastSeen: true,
+							}}
+							defaultSorting={[{ id: 'count', desc: true }]}
+						/>
+					)}
 				</CardContent>
 			</Card>
 

--- a/packages/app/src/web/components/data-table.tsx
+++ b/packages/app/src/web/components/data-table.tsx
@@ -135,8 +135,20 @@ export function DataTable<TData, TValue>({
 						{table.getHeaderGroups().map((headerGroup) => (
 							<TableRow key={headerGroup.id}>
 								{headerGroup.headers.map((header) => {
+									const sortDirection = header.column.getIsSorted();
 									return (
-										<TableHead key={header.id}>
+										<TableHead
+											key={header.id}
+											aria-sort={
+												header.column.getCanSort()
+													? sortDirection === 'asc'
+														? 'ascending'
+														: sortDirection === 'desc'
+															? 'descending'
+															: 'none'
+													: undefined
+											}
+										>
 											{header.isPlaceholder ? null : flexRender(header.column.columnDef.header, header.getContext())}
 										</TableHead>
 									);

--- a/packages/app/test/server/transport/stateless-http-transport.test.ts
+++ b/packages/app/test/server/transport/stateless-http-transport.test.ts
@@ -4,6 +4,7 @@ import {
 	MAX_METRICS_RESPONSE_CAPTURE_BYTES,
 	MetricsResponseCapture,
 	StatelessHttpTransport,
+	summarizeSubscriptionRequest,
 } from '../../../src/server/transport/stateless-http-transport.js';
 import type { ServerFactory } from '../../../src/server/transport/base-transport.js';
 import { McpServer } from '@modelcontextprotocol/server';
@@ -234,6 +235,27 @@ describe('StatelessHttpTransport', () => {
 	});
 
 	describe('unsupported resource subscriptions', () => {
+		it('summarizes subscription request shapes without retaining resource URIs', () => {
+			expect(summarizeSubscriptionRequest('resources/subscribe', { uri: 'skill://private/SKILL.md' })).toBe(
+				'uri:present'
+			);
+			expect(summarizeSubscriptionRequest('resources/subscribe', {})).toBe('uri:missing');
+			expect(
+				summarizeSubscriptionRequest('subscriptions/listen', {
+					notifications: {
+						toolsListChanged: true,
+						resourcesListChanged: false,
+						resourceSubscriptions: ['skill://private/SKILL.md', 'skill://private/OTHER.md'],
+						experimentalNotification: true,
+					},
+				})
+			).toBe(
+				'notifications:toolsListChanged:true,resourcesListChanged:false,resourceSubscriptions:2-10,unknownFields:present'
+			);
+			expect(summarizeSubscriptionRequest('subscriptions/listen', { notifications: {} })).toBe('notifications:empty');
+			expect(summarizeSubscriptionRequest('subscriptions/listen', {})).toBe('notifications:missing');
+		});
+
 		it('includes resource URIs in tracked method names', () => {
 			expect(
 				(transport as any).extractMethodForTracking({
@@ -288,6 +310,16 @@ describe('StatelessHttpTransport', () => {
 			const methodMetrics = transport.getMetrics().methods.get('resources/subscribe:skill://example/SKILL.md');
 			expect(methodMetrics).toMatchObject({ count: 1, errors: 1 });
 			expect(methodMetrics?.byClient.get(clientInfo.name)?.count).toBe(1);
+			expect(Array.from(transport.getMetrics().subscriptionAttempts.values())).toContainEqual(
+				expect.objectContaining({
+					method: 'resources/subscribe',
+					protocolEra: 'legacy',
+					clientName: clientInfo.name,
+					clientVersion: clientInfo.version,
+					requestShape: 'uri:present',
+					count: 1,
+				})
+			);
 			expect(mockServerFactory).not.toHaveBeenCalled();
 			expect(res.status).toHaveBeenCalledWith(200);
 		});
@@ -327,6 +359,17 @@ describe('StatelessHttpTransport', () => {
 
 				expect(vi.mocked(serverFactory).mock.calls).toHaveLength(factoryCallsBeforeListen);
 				expect(transport.getMetrics().methods.get('subscriptions/listen')).toMatchObject({ count: 1, errors: 1 });
+				expect(Array.from(transport.getMetrics().subscriptionAttempts.values())).toContainEqual(
+					expect.objectContaining({
+						method: 'subscriptions/listen',
+						protocolEra: 'modern',
+						protocolVersion: '2026-07-28',
+						clientName: 'modern-subscription-test',
+						clientVersion: '1.0.0',
+						requestShape: 'notifications:empty',
+						count: 1,
+					})
+				);
 				expect(
 					Array.from(transport.getMetrics().clients.values()).find(
 						(candidate) => candidate.name === 'modern-subscription-test'

--- a/packages/app/test/shared/transport-metrics.test.ts
+++ b/packages/app/test/shared/transport-metrics.test.ts
@@ -153,4 +153,76 @@ describe('MetricsCounter', () => {
 		expect(methodMetrics.get('tools/call:tool_42')?.count).toBe(2);
 		expect(methodMetrics.get('tools/call:__unexpected__')?.count).toBe(1);
 	});
+
+	it('aggregates sanitized subscription attempt behavior by client and protocol', () => {
+		const metrics = new MetricsCounter();
+		const attempt = {
+			method: 'subscriptions/listen' as const,
+			protocolEra: 'modern' as const,
+			protocolVersion: '2026-07-28',
+			clientName: 'go-sdk',
+			clientVersion: '1.2.3',
+			requestShape: 'notifications:resourceSubscriptions:1',
+		};
+
+		metrics.trackSubscriptionAttempt(attempt);
+		metrics.trackSubscriptionAttempt(attempt);
+
+		expect(formatMetricsForAPI(metrics.getMetrics(), 'streamableHttpJson', true).subscriptionAttempts).toEqual([
+			expect.objectContaining({
+				...attempt,
+				count: 2,
+				firstSeen: expect.any(String),
+				lastSeen: expect.any(String),
+			}),
+		]);
+	});
+
+	it('bounds subscription attempt dimensions and client identity lengths', () => {
+		const metrics = new MetricsCounter();
+
+		for (let index = 0; index < 502; index++) {
+			metrics.trackSubscriptionAttempt({
+				method: 'resources/subscribe',
+				protocolEra: 'legacy',
+				protocolVersion: '2025-11-25',
+				clientName: `client-${index}-${'x'.repeat(200)}`,
+				clientVersion: '1.0.0',
+				requestShape: 'uri:present',
+			});
+		}
+
+		const attempts = Array.from(metrics.getMetrics().subscriptionAttempts.values());
+		expect(attempts).toHaveLength(501);
+		expect(attempts[0]?.clientName).toHaveLength(120);
+		expect(attempts).toContainEqual(
+			expect.objectContaining({
+				method: 'resources/subscribe',
+				protocolVersion: '__other__',
+				requestShape: '__other__',
+				count: 2,
+			})
+		);
+	});
+
+	it('handles malformed and oversized subscription dimensions defensively', () => {
+		const metrics = new MetricsCounter();
+
+		expect(() =>
+			metrics.trackSubscriptionAttempt({
+				method: 'subscriptions/listen',
+				protocolEra: 'modern',
+				protocolVersion: `version-${'x'.repeat(200)}`,
+				clientName: 42 as unknown as string,
+				clientVersion: `version-${'x'.repeat(200)}`,
+				requestShape: `shape-${'x'.repeat(200)}`,
+			})
+		).not.toThrow();
+
+		const attempt = Array.from(metrics.getMetrics().subscriptionAttempts.values())[0];
+		expect(attempt?.protocolVersion).toHaveLength(120);
+		expect(attempt?.clientName).toBeUndefined();
+		expect(attempt?.clientVersion).toHaveLength(120);
+		expect(attempt?.requestShape).toHaveLength(120);
+	});
 });


### PR DESCRIPTION
## Summary

- track legacy `resources/subscribe` / `resources/unsubscribe` and modern `subscriptions/listen` attempts without changing their rejection behavior
- expose bounded, sanitized attempt aggregates through `subscriptionAttempts` in `/api/transport-metrics`
- capture protocol/client identity and modern notification-filter shape while omitting modern resource URIs
- show attempt totals, clients, protocol versions, request shapes, and timestamps in a filterable **Subscription behavior** card on the Protocols dashboard
- cap metric cardinality and untrusted dimension lengths

## Test plan

- `pnpm -C packages/app test` (32 files, 358 tests)
- `pnpm -C packages/app build`
- `pnpm -C packages/app typecheck`
- `pnpm -C packages/app lint:check`
- visually verified the Protocols dashboard with modern TS, Python, and Go-style request shapes