### PR TITLE
Harden log redaction and normalize common hf_fs URIs

### DIFF
--- a/packages/app/src/server/utils/hf-dataset-transport.ts
+++ b/packages/app/src/server/utils/hf-dataset-transport.ts
@@ -5,8 +5,36 @@ import { randomUUID } from 'node:crypto';
 import type { Transform } from 'node:stream';
 import safeStringify from 'fast-safe-stringify';
 
-const HF_TOKEN_REGEX = /hf_[A-Za-z0-9]{7,}[A-Za-z0-9-]*/g;
 const REDACTED_TOKEN = 'REDACTED_TOKEN';
+const REDACTED_VALUE = '<redacted>';
+const HF_CREDENTIAL_PATTERNS = [
+	/hf_oauth__refresh_[A-Za-z0-9]{34}(?![A-Za-z0-9])/g,
+	/hf_(?:oauth|jwt|s3)_[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/g,
+	/hf_app_[A-Za-z0-9]{32}(?![A-Za-z0-9])/g,
+	/oauth_app_secret_[A-Za-z0-9]{34}(?![A-Za-z0-9])/g,
+	/hf_[A-Za-z0-9]{34}(?![A-Za-z0-9])/g,
+] as const;
+const SENSITIVE_LOG_KEYS = new Set([
+	'apikey',
+	'accesstoken',
+	'authorization',
+	'clientsecret',
+	'cookie',
+	'credentials',
+	'env',
+	'environment',
+	'hftoken',
+	'idtoken',
+	'password',
+	'privatekey',
+	'proxyauthorization',
+	'refreshtoken',
+	'secret',
+	'secrets',
+	'setcookie',
+	'token',
+	'xapikey',
+]);
 
 export interface HfDatasetTransportOptions {
 	loggingToken: string;
@@ -246,12 +274,49 @@ function createNoOpTransport(reason: string, logType = 'Logs'): Transform {
 // Replace any string that looks like a Hugging Face token to keep uploads clean
 export function redactHfTokens(value: string): string {
 	if (!value) return value;
-	return value.replace(HF_TOKEN_REGEX, REDACTED_TOKEN);
+	return HF_CREDENTIAL_PATTERNS.reduce((redacted, pattern) => redacted.replace(pattern, REDACTED_TOKEN), value);
+}
+
+export function redactSensitiveLogValues(value: unknown): unknown {
+	return redactSensitiveLogValue(value, new WeakSet<object>());
+}
+
+function redactSensitiveLogValue(value: unknown, seen: WeakSet<object>): unknown {
+	if (Array.isArray(value)) {
+		if (seen.has(value)) {
+			return '<circular>';
+		}
+		seen.add(value);
+		const redacted = value.map((entry) => redactSensitiveLogValue(entry, seen));
+		seen.delete(value);
+		return redacted;
+	}
+	if (value !== null && typeof value === 'object') {
+		if (seen.has(value)) {
+			return '<circular>';
+		}
+		seen.add(value);
+		const redacted = Object.fromEntries(
+			Object.entries(value).map(([key, entry]) => [
+				key,
+				isSensitiveLogKey(key) ? REDACTED_VALUE : redactSensitiveLogValue(entry, seen),
+			])
+		);
+		seen.delete(value);
+		return redacted;
+	}
+	return typeof value === 'string' ? redactHfTokens(value) : value;
+}
+
+function isSensitiveLogKey(key: string): boolean {
+	const normalized = key.replace(/[-_]/g, '').toLowerCase();
+	return SENSITIVE_LOG_KEYS.has(normalized);
 }
 
 // Helper function to safely stringify log entries with consistent structure
 function safeStringifyLog(log: LogEntry, sessionId: string, logType: string): string {
 	if (!log) return ''; // Skip null/undefined logs
+	log = redactSensitiveLogValues(log) as LogEntry;
 
 	if (logType === 'Query' || logType === 'System' || logType === 'Gradio') {
 		// For query, system, and gradio logs, preserve pino's time field but strip other pino metadata

--- a/packages/app/src/server/utils/query-logger.ts
+++ b/packages/app/src/server/utils/query-logger.ts
@@ -2,6 +2,7 @@ import pino, { type Logger, type LoggerOptions } from 'pino';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
 import { SERVER_BUILD_SHA, SERVER_VERSION } from '../server-build-info.js';
+import { redactHfTokens, redactSensitiveLogValues } from './hf-dataset-transport.js';
 
 // Feature flags: enable/disable per-log-type; defaults to true
 const QUERY_LOGS_ENABLED = (process.env.LOG_QUERY_EVENTS ?? 'true').toLowerCase() === 'true';
@@ -219,11 +220,12 @@ function logQueryEvent(
 	// Use a stable mcpServerSessionId per process/transport instance
 	const mcpServerSessionId = getMcpServerSessionId();
 	const normalizedDurationMs = options?.durationMs !== undefined ? Math.round(options.durationMs) : undefined;
-	const serializedParameters = JSON.stringify(data);
+	const redactedData = redactSensitiveLogValues(data) as Record<string, unknown>;
+	const serializedParameters = JSON.stringify(redactedData);
 	const requestPayload = {
 		methodName,
 		query,
-		parameters: data,
+		parameters: redactedData,
 	};
 	const normalizedError =
 		options?.error !== undefined && options?.error !== null ? normalizeError(options.error) : null;
@@ -240,7 +242,7 @@ function logQueryEvent(
 		requestId: options?.requestId || null,
 		protocolEra: options?.protocolEra || null,
 		protocolVersion: options?.protocolVersion || null,
-		clientCapabilities: options?.clientCapabilities ? JSON.stringify(options.clientCapabilities) : null,
+		clientCapabilities: options?.clientCapabilities ? stringifyRedacted(options.clientCapabilities) : null,
 		userHash: options?.userHash || null,
 		isAuthenticated: options?.isAuthenticated ?? false,
 		name: options?.clientName || null,
@@ -321,14 +323,14 @@ export function logSystemEvent(
 			ipAddress: options?.ipAddress || null,
 
 			// Full request data for context
-			capabilities: options?.capabilities ? JSON.stringify(options.capabilities) : null,
+			capabilities: options?.capabilities ? stringifyRedacted(options.capabilities) : null,
 			clientSessionId: options?.clientSessionId || null,
 			requestId: options?.requestId || null,
 			protocolEra: options?.protocolEra || null,
 			protocolVersion: options?.protocolVersion || null,
 			userHash: options?.userHash || null,
 			requestJson: options?.requestJson
-				? JSON.stringify(options.requestJson)
+				? stringifyRedacted(options.requestJson)
 				: JSON.stringify({ methodName, sessionId }),
 			mcpServerSessionId,
 		},
@@ -388,7 +390,7 @@ export function logGradioEvent(
 			requestId: options.requestId ?? (options.protocolEra === 'modern' ? sessionId : null),
 			protocolEra: options.protocolEra || null,
 			protocolVersion: options.protocolVersion || null,
-			clientCapabilities: options.clientCapabilities ? JSON.stringify(options.clientCapabilities) : null,
+			clientCapabilities: options.clientCapabilities ? stringifyRedacted(options.clientCapabilities) : null,
 			userHash: options.userHash || null,
 			endpointName, // e.g., "user/repo"
 			name: options.clientName || null,
@@ -408,14 +410,18 @@ export function logGradioEvent(
 
 function normalizeError(error: unknown): string {
 	if (error instanceof Error) {
-		return `${error.name}: ${error.message}`;
+		return redactHfTokens(`${error.name}: ${error.message}`);
 	}
 	if (typeof error === 'string') {
-		return error;
+		return redactHfTokens(error);
 	}
 	try {
-		return JSON.stringify(error);
+		return stringifyRedacted(error);
 	} catch {
-		return String(error);
+		return redactHfTokens(String(error));
 	}
+}
+
+function stringifyRedacted(value: unknown): string {
+	return JSON.stringify(redactSensitiveLogValues(value));
 }

--- a/packages/app/test/server/utils/hf-dataset-transport.test.ts
+++ b/packages/app/test/server/utils/hf-dataset-transport.test.ts
@@ -4,6 +4,7 @@ import {
 	type HfDatasetTransportOptions,
 	type LogEntry,
 	redactHfTokens,
+	redactSensitiveLogValues,
 } from '../../../src/server/utils/hf-dataset-transport.js';
 import type { CommitOutput } from '@huggingface/hub';
 import { tmpdir } from 'node:os';
@@ -343,14 +344,55 @@ describe('HfDatasetLogger', () => {
 	});
 
 	describe('Token redaction', () => {
-		it('redacts strings that look like HF tokens', () => {
-			const tokenLikeString = 'hf_xzzzzzz';
-			const withContext = `Bearer ${tokenLikeString} extra`;
-			const notToken = 'hf_short';
+		it('redacts supported Hugging Face credential formats without corrupting identifiers', () => {
+			const credentials = [
+				`hf_${'a'.repeat(34)}`,
+				`hf_app_${'b'.repeat(32)}`,
+				`hf_oauth_${'c'.repeat(32)}.${'d'.repeat(32)}.${'e'.repeat(32)}`,
+				`hf_oauth__refresh_${'f'.repeat(34)}`,
+				`hf_jwt_${'g'.repeat(32)}.${'h'.repeat(32)}.${'i'.repeat(32)}`,
+				`hf_s3_${'j'.repeat(32)}.${'k'.repeat(32)}.${'l'.repeat(32)}`,
+				`oauth_app_secret_${'m'.repeat(34)}`,
+			];
+			for (const credential of credentials) {
+				expect(redactHfTokens(`Bearer ${credential} extra`)).toBe('Bearer REDACTED_TOKEN extra');
+			}
+			for (const identifier of [
+				'hf_sandbox',
+				'hf_sandbox_exec',
+				'hf_sandbox_fs',
+				'hf_semantic_search',
+				'hf_oauth_config',
+				'hf_jwt_debug',
+				'hf_s3_client',
+			]) {
+				expect(redactHfTokens(identifier)).toBe(identifier);
+			}
+			expect(redactHfTokens(`hf_${'a'.repeat(35)}`)).toBe(`hf_${'a'.repeat(35)}`);
+		});
 
-			expect(redactHfTokens(tokenLikeString)).toBe('REDACTED_TOKEN');
-			expect(redactHfTokens(withContext)).toBe('Bearer REDACTED_TOKEN extra');
-			expect(redactHfTokens(notToken)).toBe('hf_short');
+		it('redacts nested sensitive values while preserving their keys', () => {
+			expect(
+				redactSensitiveLogValues({
+					secrets: { HF_TOKEN: `hf_oauth_${'a'.repeat(64)}` },
+					environment: { SAFE: 'value' },
+					nested: {
+						access_token: `hf_${'b'.repeat(34)}`,
+						clientSecret: 'secret',
+						'x-api-key': 'key',
+						label: 'keep',
+					},
+				})
+			).toEqual({
+				secrets: '<redacted>',
+				environment: '<redacted>',
+				nested: {
+					access_token: '<redacted>',
+					clientSecret: '<redacted>',
+					'x-api-key': '<redacted>',
+					label: 'keep',
+				},
+			});
 		});
 
 		it('redacts tokens before upload', async () => {
@@ -374,7 +416,8 @@ describe('HfDatasetLogger', () => {
 			logger.processLog({
 				level: 30,
 				time: Date.now(),
-				msg: 'Contains hf_xzzzzzz in message',
+				msg: `Contains hf_oauth_${'x'.repeat(32)}.${'y'.repeat(32)}.${'z'.repeat(32)} in message`,
+				apiKey: 'non-hf-secret',
 			});
 
 			await (logger as unknown as { flush: () => Promise<void> }).flush();
@@ -385,7 +428,8 @@ describe('HfDatasetLogger', () => {
 			const uploaded = await blobContent.file.content.text();
 
 			expect(uploaded).toContain('REDACTED_TOKEN');
-			expect(uploaded).not.toMatch(/hf_[A-Za-z0-9]{7,}[A-Za-z0-9-]*/);
+			expect(uploaded).not.toContain('hf_oauth_');
+			expect(uploaded).not.toContain('non-hf-secret');
 		});
 	});
 });

--- a/packages/mcp/src/hf-fs-contract.test.ts
+++ b/packages/mcp/src/hf-fs-contract.test.ts
@@ -234,9 +234,70 @@ describe('parseHfFsRequest', () => {
 		});
 	});
 
+	it('normalizes typed shorthand and Hugging Face web URLs', () => {
+		for (const [input, uri] of [
+			['models/openai/gpt2', 'hf://models/openai/gpt2'],
+			['datasets/openai/example/README.md', 'hf://datasets/openai/example/README.md'],
+			['https://huggingface.co/openai/gpt2', 'hf://models/openai/gpt2'],
+			['https://huggingface.co/openai/gpt2/blob/main/README.md', 'hf://models/openai/gpt2/README.md'],
+			['https://huggingface.co/openai/gpt2/blob/dev/README.md', 'hf://models/openai/gpt2@dev/README.md'],
+			[
+				'https://huggingface.co/openai/gpt2/resolve/refs%2Fpr%2F3/README.md',
+				'hf://models/openai/gpt2@refs%2Fpr%2F3/README.md',
+			],
+			['https://huggingface.co/datasets/openai/example/tree/main/data', 'hf://datasets/openai/example/data'],
+			['https://www.huggingface.co/spaces/openai/demo', 'hf://spaces/openai/demo'],
+			[
+				'https://huggingface.co/buckets/openai/assets/resolve/images/logo.png',
+				'hf://buckets/openai/assets/images/logo.png',
+			],
+			['https://huggingface.co/docs/transformers/main/en/index', 'hf://docs/transformers/main/en/index'],
+			['docs/transformers/main/en/index', 'hf://docs/transformers/main/en/index'],
+			['https://huggingface.co/papers/2501.00001', 'hf://papers/2501.00001'],
+		] as const) {
+			expect(parseHfFsRequest({ cmd: 'ls', args: [input] }).params.uri).toBe(uri);
+		}
+	});
+
+	it('keeps non-Hugging Face and insecure web URLs outside the hf:// namespace', () => {
+		for (const uri of [
+			'https://example.com/models/org/repo',
+			'http://huggingface.co/models/org/repo',
+			'https://huggingface.co/settings/tokens',
+			'https://huggingface.co/openai/gpt2/discussions',
+			'https://huggingface.co/openai/gpt2?download=true',
+			'https://user@huggingface.co/openai/gpt2',
+		]) {
+			expect(() => parseHfFsRequest({ cmd: 'ls', args: [uri] })).toThrow('URI must start with hf://');
+		}
+	});
+
+	it('treats --sort trending on listing roots as the trending virtual directory', () => {
+		for (const root of ['models', 'datasets', 'spaces', 'papers']) {
+			expect(
+				parseHfFsRequest({
+					cmd: 'ls',
+					args: [`hf://${root}`, '--sort', 'trending'],
+				})
+			).toEqual({
+				params: {
+					op: 'ls',
+					uri: `hf://${root}/trending`,
+				},
+				warnings: [`Treated --sort trending on hf://${root} as hf://${root}/trending.`],
+			});
+		}
+		expect(parseHfFsRequest({ cmd: 'ls', args: ['models/', '--sort', 'trending'] }).params.uri).toBe(
+			'hf://models/trending'
+		);
+		expect(() => parseHfFsRequest({ cmd: 'ls', args: ['hf://models', '--sort', 'trending', '--recursive'] })).toThrow(
+			'--sort trending does not support recursive or glob'
+		);
+	});
+
 	it.each([
 		[{ cmd: 'ls', args: [] }, 'ls requires an hf:// URI'],
-		[{ cmd: 'stat', args: ['models/org/repo'] }, 'URI must start with hf://'],
+		[{ cmd: 'stat', args: ['owner/repo'] }, 'URI must start with hf://'],
 		[{ cmd: 'stat', args: ['hf://models/org/repo', '--limit', '1'] }, 'unexpected argument for stat'],
 		[{ cmd: 'ls', args: ['hf://models/org', '--limit'] }, '--limit requires a value'],
 		[{ cmd: 'ls', args: ['hf://models/org', '--limit', 'many'] }, '--limit requires an integer'],

--- a/packages/mcp/src/hf-fs-contract.ts
+++ b/packages/mcp/src/hf-fs-contract.ts
@@ -52,7 +52,7 @@ Grammar; each token below is one args array element:
 TYPE = file|dir|repo|bucket|collection|paper|link.
 Type aliases: f=file, d=dir, l=link, model|dataset|space=repo.
 SORT = createdAt|downloads|likes|lastModified|likes30d|trendingScore|mainSize|id|trending|upvotes.
-URI starts with hf://. QUERY and GLOB are each one string token.
+URI uses hf://, a typed shorthand such as models/OWNER/REPO, or a canonical https://huggingface.co URL. QUERY and GLOB are each one string token.
 Search URI: hf://models|datasets|spaces[/OWNER], hf://collections[/OWNER], any hf://docs scope, or exactly hf://papers; not hf://.
 Repository and collection searches may omit QUERY to browse or filter; documentation and paper searches require it.
 Search joins multiple positional QUERY tokens with spaces. Cat and stat join one RELATIVE_PATH token to URI.
@@ -158,7 +158,7 @@ export function parseHfFsRequest(request: HfFsRequest): ParsedHfFsRequest {
 		throw new Error(`EINVAL: ${request.cmd} requires an hf:// URI`);
 	}
 
-	let uri = positionals[0];
+	let uri = normalizeHfFsUri(positionals[0] ?? '');
 	if (!uri?.startsWith('hf://')) {
 		throw new Error('EINVAL: URI must start with hf://');
 	}
@@ -196,8 +196,120 @@ export function parseHfFsRequest(request: HfFsRequest): ParsedHfFsRequest {
 		...(typeof options.offset === 'number' ? { offset: options.offset } : {}),
 		...(typeof options.limit === 'number' ? { limit: options.limit } : {}),
 	};
+	const normalizationWarnings = normalizeParsedParams(params);
 	validateParsedParams(params);
-	return softenParsedParams(params);
+	const softened = softenParsedParams(params);
+	return { params: softened.params, warnings: [...normalizationWarnings, ...softened.warnings] };
+}
+
+function normalizeHfFsUri(value: string): string {
+	if (/^(?:models|datasets|spaces|buckets|collections|papers|docs)(?:\/|$)/.test(value)) {
+		return `hf://${value.replace(/\/+$/, '')}`;
+	}
+	if (!/^https?:\/\//i.test(value)) {
+		return value;
+	}
+
+	let url: URL;
+	try {
+		url = new URL(value);
+	} catch {
+		return value;
+	}
+	if (
+		url.protocol !== 'https:' ||
+		!['huggingface.co', 'www.huggingface.co'].includes(url.hostname) ||
+		url.port ||
+		url.username ||
+		url.password ||
+		url.search ||
+		url.hash
+	) {
+		return value;
+	}
+
+	const segments = url.pathname.split('/').filter(Boolean);
+	if (segments.length === 0) {
+		return 'hf://';
+	}
+	const first = segments[0] ?? '';
+	if (['models', 'datasets', 'spaces', 'buckets', 'collections', 'papers', 'docs'].includes(first)) {
+		return normalizeTypedHfWebPath(segments);
+	}
+	const isRepoFileUrl = segments.length >= 4 && ['blob', 'resolve', 'tree'].includes(segments[2] ?? '');
+	if (segments.length !== 2 && !isRepoFileUrl) {
+		return value;
+	}
+	if (
+		[
+			'api',
+			'collections',
+			'datasets',
+			'docs',
+			'join',
+			'login',
+			'models',
+			'new',
+			'organizations',
+			'papers',
+			'pricing',
+			'search',
+			'settings',
+			'spaces',
+		].includes(first)
+	) {
+		return value;
+	}
+	return normalizeRepoWebPath('models', segments);
+}
+
+function normalizeTypedHfWebPath(segments: string[]): string {
+	const type = segments[0] ?? '';
+	if (type === 'models' && segments.length >= 3) {
+		return normalizeRepoWebPath(type, segments.slice(1));
+	}
+	if (['datasets', 'spaces'].includes(type) && segments.length >= 3) {
+		return normalizeRepoWebPath(type, segments.slice(1));
+	}
+	if (type === 'buckets' && segments.length >= 4 && segments[3] === 'resolve') {
+		return `hf://buckets/${[segments[1], segments[2], ...segments.slice(4)].join('/')}`;
+	}
+	return `hf://${segments.join('/')}`;
+}
+
+function normalizeRepoWebPath(type: string, segments: string[]): string {
+	if (segments.length < 2) {
+		return `hf://${type}/${segments.join('/')}`;
+	}
+	const [owner, repo, route, revision, ...path] = segments;
+	if (route === 'blob' || route === 'resolve' || route === 'tree') {
+		if (!revision) {
+			return `hf://${type}/${owner}/${repo}`;
+		}
+		const repoWithRevision = revision === 'main' ? repo : `${repo}@${revision}`;
+		return `hf://${type}/${[owner, repoWithRevision, ...path].join('/')}`;
+	}
+	if (segments.length > 2) {
+		return `https://huggingface.co/${type === 'models' ? '' : `${type}/`}${segments.join('/')}`;
+	}
+	return `hf://${type}/${segments.join('/')}`;
+}
+
+function normalizeParsedParams(params: HfFsParams): string[] {
+	if (
+		params.op === 'ls' &&
+		params.sort === 'trending' &&
+		/^hf:\/\/(?:models|datasets|spaces|papers)$/.test(params.uri)
+	) {
+		if (params.recursive || params.glob) {
+			throw new Error('EINVAL: --sort trending does not support recursive or glob listing options');
+		}
+		const source = params.uri;
+		params.uri = `${source}/trending`;
+		delete params.sort;
+		return [`Treated --sort trending on ${source} as ${params.uri}.`];
+	}
+	return [];
 }
 
 function validateParsedParams(params: HfFsParams): void {


### PR DESCRIPTION
## Summary

- harden dataset-log redaction using authoritative Hub credential formats and recursive sensitive-key filtering
- preserve legitimate tool identifiers such as `hf_sandbox*` while covering user, OAuth, app, JWT, S3, refresh, and OAuth-app credentials
- accept typed `hf_fs` shorthand such as `models/OWNER/REPO`
- normalize canonical Hugging Face repository, file, docs, paper, and bucket URLs into `hf://` URIs
- treat `ls hf://TYPE --sort trending` as the corresponding `/trending` virtual directory

## Security notes

The logging changes keep final serialized-record credential scanning as defense in depth and additionally redact sensitive values before nested request data is stringified. Credential prefixes and lengths were checked against Moon Landing's token generation paths.

## Validation

- `pnpm -C packages/mcp lint:check`
- `pnpm -C packages/app lint:check`
- `pnpm -C packages/mcp typecheck`
- `pnpm -C packages/app typecheck`
- `pnpm -C packages/mcp test` — 298 passed
- `pnpm -C packages/app test` — 359 passed
- `pnpm -C packages/mcp build`
- `pnpm -C packages/app build:server`
- Prettier and `git diff --check`
