### PR TITLE
Remove Skybridge absence tests

### DIFF
--- a/packages/app/test/server/gradio-endpoint-connector.test.ts
+++ b/packages/app/test/server/gradio-endpoint-connector.test.ts
@@ -298,7 +298,7 @@ describe('parseSchemaResponse', () => {
 });
 
 describe('registerRemoteTools', () => {
-	it('proxies advertised MCP Apps without injecting OpenAI widget metadata', async () => {
+	it('proxies advertised MCP Apps', async () => {
 		const server = new McpServer({ name: 'gradio-app-test', version: '1.0.0' });
 		const connection: EndpointConnection = {
 			endpointId: 'gradio_owner-space',
@@ -326,9 +326,7 @@ describe('registerRemoteTools', () => {
 				},
 			],
 		};
-		registerRemoteTools(server, connection, undefined, {
-			clientInfo: { name: 'openai-mcp', version: '1.0.0' },
-		});
+		registerRemoteTools(server, connection);
 
 		const client = new Client({ name: 'test-client', version: '1.0.0' });
 		const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
@@ -349,8 +347,6 @@ describe('registerRemoteTools', () => {
 					csp: { connectSrc: ['https://huggingface.co'] },
 				},
 			});
-			expect(tools[0]?._meta).not.toHaveProperty('openai/outputTemplate');
-			expect(tools[1]?._meta).not.toHaveProperty('openai/outputTemplate');
 		} finally {
 			await client.close();
 			await server.close();

--- a/packages/app/test/server/immutable-tool-registration.test.ts
+++ b/packages/app/test/server/immutable-tool-registration.test.ts
@@ -55,25 +55,4 @@ describe('immutable tool registration', () => {
 		process.env.DISABLE_TOOLS = REPO_SEARCH_TOOL_ID;
 		expect((await inspectSearchBouquet()).toolNames).toEqual(['hf_whoami', HF_FS_TOOL_ID]);
 	});
-
-	it('does not register a built-in widget for OpenAI clients', async () => {
-		const apiClient = new McpApiClient({ type: 'static' }, transportInfo);
-		const factory = createServerFactory(new WebServer(), apiClient);
-		const { server } = await factory(
-			{ 'x-mcp-bouquet': 'search' },
-			undefined,
-			undefined,
-			{ clientInfo: { name: 'openai-mcp', version: '1.0.0' } }
-		);
-		const client = new Client({ name: 'openai-mcp', version: '1.0.0' });
-		const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
-		await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
-
-		try {
-			expect(client.getServerCapabilities()?.resources).toBeUndefined();
-		} finally {
-			await client.close();
-			await server.close();
-		}
-	});
 });


### PR DESCRIPTION
## Summary

- remove the regression test that only asserted the deleted built-in widget was absent
- keep the positive MCP App proxy test, but remove its Skybridge/OpenAI-specific setup and negative metadata assertions

Once the Skybridge implementation is deleted, tests should cover the remaining behavior rather than preserve the absence of removed behavior.

## Validation

- `pnpm -C packages/mcp build`
- `pnpm -C packages/app exec vitest run test/server/immutable-tool-registration.test.ts test/server/gradio-endpoint-connector.test.ts` — 31 tests passed
- targeted Prettier check
- `git diff --check`
