### PR TITLE
Add context-cost badge (4,691 tokens, reproducibly measured)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 Welcome to the official Hugging Face MCP Server 🤗. Connect your LLM to the Hugging Face Hub and thousands of Gradio AI Applications.
 
+[![context cost](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fathakur3%2Fmcp-context-cost%2Fmain%2Fbadges%2Fhuggingface.json)](https://athakur3.github.io/mcp-context-cost/METHODOLOGY)
+
 ## Installing the MCP Server
 
 Follow the instructions below to get started:


### PR DESCRIPTION
One line: a shields.io badge showing what the anonymous-access hf-mcp-server costs in context tokens — currently **4,691 tokens across 4 tools** (measured 2026-08-16 over the public endpoint via the mcp-remote bridge; largest: `hf_whoami` at 1,948, `hf_fs` at 1,924). Median across 57 popular MCP servers we measured: 2,636.

The per-tool breakdown may be useful independently of the badge: two tools carry 83% of the cost, mostly in long descriptions — [results/huggingface/measurement.json](https://github.com/athakur3/mcp-context-cost/blob/main/results/huggingface/measurement.json) has the full capture. The number links to a reproducible methodology (raw `tools/list` capture + pinned `o200k_base` tokenizer, re-derivable in five lines); the badge JSON refreshes weekly.

If you'd rather not carry this, close freely — no hard feelings. To own the number in your own CI instead: sd2k/mcp-tokens-action (badge support proposed in sd2k/mcp-tokens-action#5).