### PR TITLE
fix(jobs): tolerate unstable owner/createdBy shapes from Jobs API

### DIFF
--- a/packages/mcp/src/jobs/hf-jobs-output-schema.ts
+++ b/packages/mcp/src/jobs/hf-jobs-output-schema.ts
@@ -19,7 +19,7 @@ export const HF_JOBS_OPERATIONS = [
 const ownerSchema = z.strictObject({
 	id: z.string(),
 	name: z.string(),
-	type: z.enum(['user', 'org']),
+	type: z.enum(['user', 'org']).optional(),
 });
 
 const jobStatusSchema = z.strictObject({

--- a/packages/mcp/src/jobs/jobs-output.ts
+++ b/packages/mcp/src/jobs/jobs-output.ts
@@ -7,7 +7,7 @@ import {
 	type HfJobsOutput,
 	type HfScheduledJobOutput,
 } from './hf-jobs-output-schema.js';
-import type { JobInfo, JobSpec, ScheduledJobInfo } from './types.js';
+import type { JobInfo, JobOwner, JobSpec, ScheduledJobInfo } from './types.js';
 
 export interface JobsCommandResult {
 	formatted: string;
@@ -19,6 +19,19 @@ export interface JobsCommandResult {
 
 export interface HfJobsToolResult extends ToolResult {
 	structuredContent: HfJobsOutput;
+}
+
+/**
+ * The Jobs API's owner/createdBy objects are not schema-stable (e.g. extra
+ * profile fields, or a missing `type`). Pick only the fields the output
+ * schema promises instead of spreading the raw API object.
+ */
+function normalizeOwner(owner: JobOwner): { id: string; name: string; type?: 'user' | 'org' } {
+	return {
+		id: owner.id,
+		name: owner.name,
+		...(owner.type === 'user' || owner.type === 'org' ? { type: owner.type } : {}),
+	};
 }
 
 export function toHfJobOutput(
@@ -48,8 +61,8 @@ export function toHfJobOutput(
 				: {}),
 			...(job.status.expose_urls ? { expose_urls: job.status.expose_urls.map(redact) } : {}),
 		},
-		owner: { ...job.owner },
-		...(job.createdBy ? { created_by: { ...job.createdBy } } : {}),
+		owner: normalizeOwner(job.owner),
+		...(job.createdBy ? { created_by: normalizeOwner(job.createdBy) } : {}),
 		...(job.tags ? { tags: job.tags.map(redact) } : {}),
 		...(job.labels
 			? { labels: Object.fromEntries(Object.entries(job.labels).map(([key, value]) => [key, redact(value)])) }
@@ -70,7 +83,7 @@ export function toHfScheduledJobOutput(
 		suspended: job.suspend,
 		...(job.lastRun ? { last_run: job.lastRun } : {}),
 		...(job.nextRun ? { next_run: job.nextRun } : {}),
-		owner: { ...job.owner },
+		owner: normalizeOwner(job.owner),
 		created_at: job.createdAt,
 		job_spec: {
 			...(job.jobSpec.dockerImage ? { docker_image: redact(job.jobSpec.dockerImage) } : {}),

--- a/packages/mcp/src/jobs/types.ts
+++ b/packages/mcp/src/jobs/types.ts
@@ -58,7 +58,7 @@ export interface JobStatus {
 export interface JobOwner {
 	id: string;
 	name: string;
-	type: 'user' | 'org';
+	type?: 'user' | 'org';
 }
 
 /**

--- a/packages/mcp/test/jobs/jobs-output.spec.ts
+++ b/packages/mcp/test/jobs/jobs-output.spec.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { HfApiError } from '../../src/hf-api-call.js';
 import { JobsApiClient } from '../../src/jobs/api-client.js';
-import { HF_JOBS_OUTPUT_SCHEMA } from '../../src/jobs/hf-jobs-output-schema.js';
+import { HF_JOB_OUTPUT_SCHEMA, HF_JOBS_OUTPUT_SCHEMA } from '../../src/jobs/hf-jobs-output-schema.js';
 import {
 	collectSensitiveValues,
 	redactSensitiveText,
@@ -9,7 +9,7 @@ import {
 	toHfScheduledJobOutput,
 } from '../../src/jobs/jobs-output.js';
 import { HfJobsTool } from '../../src/jobs/jobs-tool.js';
-import type { JobInfo, ScheduledJobInfo } from '../../src/jobs/types.js';
+import type { JobInfo, JobOwner, ScheduledJobInfo } from '../../src/jobs/types.js';
 
 const mocks = vi.hoisted(() => ({
 	fetchJobLogs: vi.fn(),
@@ -118,6 +118,56 @@ describe('HF Jobs structured output', () => {
 		});
 		expect(JSON.stringify(output)).not.toContain('plain-value');
 		expect(JSON.stringify(output)).not.toContain('real-secret');
+	});
+
+	it('tolerates owner objects with extra profile fields (e.g. avatarUrl) from the Jobs API', () => {
+		const output = toHfJobOutput({
+			...job,
+			owner: { id: 'user-1', name: 'alice', type: 'user', avatarUrl: 'https://example.com/a.png' } as JobOwner,
+		});
+
+		expect(output.owner).toEqual({ id: 'user-1', name: 'alice', type: 'user' });
+		expect(() => HF_JOB_OUTPUT_SCHEMA.parse(output)).not.toThrow();
+	});
+
+	it('tolerates a createdBy object missing type', () => {
+		const output = toHfJobOutput({
+			...job,
+			createdBy: { id: 'user-1', name: 'alice' } as JobOwner,
+		});
+
+		expect(output.created_by).toEqual({ id: 'user-1', name: 'alice' });
+		expect(() => HF_JOB_OUTPUT_SCHEMA.parse(output)).not.toThrow();
+	});
+
+	it('accepts baseline owner shapes with and without type', () => {
+		const withType = toHfJobOutput({ ...job, owner: { id: 'user-1', name: 'alice', type: 'org' } });
+		const withoutType = toHfJobOutput({ ...job, owner: { id: 'user-1', name: 'alice' } });
+
+		expect(withType.owner).toEqual({ id: 'user-1', name: 'alice', type: 'org' });
+		expect(withoutType.owner).toEqual({ id: 'user-1', name: 'alice' });
+		expect(() => HF_JOB_OUTPUT_SCHEMA.parse(withType)).not.toThrow();
+		expect(() => HF_JOB_OUTPUT_SCHEMA.parse(withoutType)).not.toThrow();
+	});
+
+	it('preserves job id and status when owner/createdBy metadata is malformed end-to-end via the tool', async () => {
+		vi.spyOn(JobsApiClient.prototype, 'getJob').mockResolvedValue({
+			...job,
+			status: { stage: 'COMPLETED' },
+			owner: { id: 'user-1', name: 'alice', type: 'user', avatarUrl: 'https://example.com/a.png' } as JobOwner,
+			createdBy: { id: 'user-1', name: 'alice' } as JobOwner,
+		});
+
+		const result = await new HfJobsTool('token', true).execute({
+			operation: 'inspect',
+			args: { job_id: 'job-123' },
+		});
+
+		expect(result.isError).toBeUndefined();
+		expect(result.structuredContent.outcome).toMatchObject({
+			kind: 'inspections',
+			inspections: [{ job_id: 'job-123', status: 'success', job: { id: 'job-123', status: { stage: 'COMPLETED' } } }],
+		});
 	});
 
 	it('redacts known values longest-first', () => {


### PR DESCRIPTION
The strict owner/createdBy schema in the Jobs MCP output layer rejected valid API responses in two cases: an extra profile field on owner (e.g. avatarUrl), and a createdBy object missing type. Both caused the structured-output parse to throw after a job was already created, so the caller never got back a usable job.id for logs/inspect follow-up.

Make JobOwner.type optional and add normalizeOwner() to pick only the id/name/type fields the schema promises instead of spreading the raw API object, so unexpected extra fields and a missing type no longer break parsing.