### PR TITLE
Report hf_fs batch health in telemetry and dashboard

### DIFF
--- a/packages/app/src/server/mcp-server.ts
+++ b/packages/app/src/server/mcp-server.ts
@@ -64,6 +64,12 @@ import { SERVER_VERSION } from './server-build-info.js';
 import { parseDisabledTools } from './utils/disabled-tools.js';
 import { createProgressRelay } from './utils/progress-relay.js';
 import { getToolResultErrorMessage } from './utils/observability.js';
+import {
+	summarizeCompletedHfFsBatch,
+	summarizeInterruptedHfFsBatch,
+	type CompletedHfFsQueryTelemetry,
+} from './utils/hf-fs-telemetry.js';
+import { recordHfFsLiveMetrics } from './utils/hf-fs-live-metrics.js';
 import { AUTHENTICATION_UNVERIFIED_GUIDANCE, createHfWhoamiOutput, formatHfWhoamiMarkdown } from './utils/hf-whoami.js';
 import { fetchHfWhoami } from './utils/hf-whoami-client.js';
 import { hfWhoamiOutputSchema } from './output-schemas/hf-whoami-output-schema.js';
@@ -98,9 +104,14 @@ interface PreparedHfFsBatchExecution {
 	text: string;
 	images: { data: string; mimeType: 'image/jpeg' | 'image/png' | 'image/webp' }[];
 	successCount: number;
+	telemetry: CompletedHfFsQueryTelemetry;
 }
 
-function prepareHfFsBatchExecution(items: readonly HfFsBatchExecutionItem[]): PreparedHfFsBatchExecution {
+function prepareHfFsBatchExecution(
+	requestedCount: number,
+	items: readonly HfFsBatchExecutionItem[]
+): PreparedHfFsBatchExecution {
+	const telemetry = summarizeCompletedHfFsBatch(requestedCount, items);
 	const images = items.flatMap((item) => {
 		if (item.status !== 'success' || !isHfFsAttachExecutionResult(item.executionResult)) {
 			return [];
@@ -116,7 +127,8 @@ function prepareHfFsBatchExecution(items: readonly HfFsBatchExecutionItem[]): Pr
 		structuredContent: toHfFsBatchResult(items),
 		text: formatHfFsBatchMarkdown(items),
 		images,
-		successCount: items.filter((item) => item.status === 'success').length,
+		successCount: telemetry.hfFsOperationsSucceeded,
+		telemetry,
 	};
 }
 
@@ -209,6 +221,7 @@ export const createServerFactory = (sharedApiClient: McpApiClient): ServerFactor
 			parameters: Record<string, unknown>;
 			baseOptions?: BaseQueryLoggerOptions;
 			successOptions?: (result: T) => BaseQueryLoggerOptions | void;
+			failureOptions?: (error: unknown) => BaseQueryLoggerOptions | void;
 		}
 
 		const runWithQueryLogging = async <T>(
@@ -235,10 +248,13 @@ export const createServerFactory = (sharedApiClient: McpApiClient): ServerFactor
 				return result;
 			} catch (error) {
 				const durationMs = Math.round(performance.now() - start);
+				const failureOptions = config.failureOptions?.(error) ?? {};
+				const { success: successOverride, ...restFailureOptions } = failureOptions;
 				logFn(config.methodName, config.query, config.parameters, {
 					...config.baseOptions,
+					...restFailureOptions,
 					durationMs,
-					success: false,
+					success: successOverride ?? false,
 					error,
 				});
 				throw error;
@@ -471,12 +487,22 @@ export const createServerFactory = (sharedApiClient: McpApiClient): ServerFactor
 								},
 								baseOptions: getLoggingOptions(),
 								successOptions: (batchResult) => {
+									recordHfFsLiveMetrics(batchResult.telemetry);
 									return {
 										totalResults: request.operations.length,
 										resultsShared: batchResult.successCount,
 										responseCharCount: batchResult.text.length,
 										success: batchResult.successCount > 0,
+										...batchResult.telemetry,
 									};
+								},
+								failureOptions: () => {
+									const telemetry = summarizeInterruptedHfFsBatch(
+										request.operations.length,
+										ctx.mcpReq.signal.aborted ? 'cancelled' : 'failed'
+									);
+									recordHfFsLiveMetrics(telemetry);
+									return telemetry;
 								},
 							},
 							async () => {
@@ -486,7 +512,7 @@ export const createServerFactory = (sharedApiClient: McpApiClient): ServerFactor
 								});
 								// Encode before success telemetry is emitted. Only aggregate metrics reach
 								// logToolQuery; neither Uint8Array data nor base64 image content is logged.
-								return prepareHfFsBatchExecution(executionItems);
+								return prepareHfFsBatchExecution(request.operations.length, executionItems);
 							}
 						);
 						return {

--- a/packages/app/src/server/utils/hf-fs-live-metrics.ts
+++ b/packages/app/src/server/utils/hf-fs-live-metrics.ts
@@ -1,0 +1,68 @@
+import type { HfFsLiveMetricsResponse } from '../../shared/transport-metrics.js';
+import type { HfFsQueryTelemetry } from './hf-fs-telemetry.js';
+
+function emptyMetrics(): HfFsLiveMetricsResponse {
+	return {
+		reportingSchema: 'hf_fs_batch_v1',
+		batches: {
+			total: 0,
+			complete: 0,
+			partial: 0,
+			noneSucceeded: 0,
+			failed: 0,
+			cancelled: 0,
+		},
+		operations: {
+			completed: 0,
+			succeeded: 0,
+			requestErrors: 0,
+			targetErrors: 0,
+			policyLimitErrors: 0,
+			serviceErrors: 0,
+		},
+		lastUpdated: null,
+	};
+}
+
+let metrics = emptyMetrics();
+
+export function recordHfFsLiveMetrics(telemetry: HfFsQueryTelemetry): void {
+	metrics.batches.total += 1;
+	switch (telemetry.hfFsBatchOutcome) {
+		case 'complete':
+			metrics.batches.complete += 1;
+			break;
+		case 'partial':
+			metrics.batches.partial += 1;
+			break;
+		case 'none_succeeded':
+			metrics.batches.noneSucceeded += 1;
+			break;
+		case 'failed':
+			metrics.batches.failed += 1;
+			break;
+		case 'cancelled':
+			metrics.batches.cancelled += 1;
+			break;
+	}
+	metrics.operations.completed += telemetry.hfFsOperationsCompleted ?? 0;
+	metrics.operations.succeeded += telemetry.hfFsOperationsSucceeded ?? 0;
+	metrics.operations.requestErrors += telemetry.hfFsRequestErrorCount ?? 0;
+	metrics.operations.targetErrors += telemetry.hfFsTargetErrorCount ?? 0;
+	metrics.operations.policyLimitErrors += telemetry.hfFsPolicyLimitErrorCount ?? 0;
+	metrics.operations.serviceErrors += telemetry.hfFsServiceErrorCount ?? 0;
+	metrics.lastUpdated = new Date().toISOString();
+}
+
+export function getHfFsLiveMetrics(): HfFsLiveMetricsResponse {
+	return {
+		reportingSchema: metrics.reportingSchema,
+		batches: { ...metrics.batches },
+		operations: { ...metrics.operations },
+		lastUpdated: metrics.lastUpdated,
+	};
+}
+
+export function resetHfFsLiveMetricsForTests(): void {
+	metrics = emptyMetrics();
+}

--- a/packages/app/src/server/utils/hf-fs-telemetry.ts
+++ b/packages/app/src/server/utils/hf-fs-telemetry.ts
@@ -1,0 +1,115 @@
+import {
+	HF_FS_BATCH_MAX_OPERATIONS,
+	hfFsErrorClass,
+	type HfFsBatchExecutionItem,
+	type HfFsErrorClass,
+	type HfFsRecoveryError,
+} from '@llmindset/hf-mcp';
+
+export const HF_FS_REPORTING_SCHEMA = 'hf_fs_batch_v1' as const;
+
+export type HfFsBatchOutcome = 'complete' | 'partial' | 'none_succeeded' | 'failed' | 'cancelled';
+
+interface HfFsOperationErrorTelemetry {
+	index: number;
+	code: HfFsRecoveryError['code'];
+	suggestedOperation?: HfFsRecoveryError['suggestedOperation'];
+}
+
+export interface HfFsQueryTelemetry {
+	hfFsReportingSchema: typeof HF_FS_REPORTING_SCHEMA;
+	hfFsBatchOutcome: HfFsBatchOutcome;
+	hfFsOperationsRequested: number;
+	hfFsOperationsCompleted?: number;
+	hfFsOperationsSucceeded?: number;
+	hfFsRequestErrorCount?: number;
+	hfFsTargetErrorCount?: number;
+	hfFsPolicyLimitErrorCount?: number;
+	hfFsServiceErrorCount?: number;
+	hfFsOperationErrorsJson: string;
+}
+
+export interface CompletedHfFsQueryTelemetry extends HfFsQueryTelemetry {
+	hfFsOperationsCompleted: number;
+	hfFsOperationsSucceeded: number;
+	hfFsRequestErrorCount: number;
+	hfFsTargetErrorCount: number;
+	hfFsPolicyLimitErrorCount: number;
+	hfFsServiceErrorCount: number;
+}
+
+const EMPTY_ERROR_COUNTS = {
+	request: 0,
+	target: 0,
+	policy_limit: 0,
+	service: 0,
+} satisfies Record<HfFsErrorClass, number>;
+
+export function summarizeCompletedHfFsBatch(
+	requestedCount: number,
+	items: readonly HfFsBatchExecutionItem[]
+): CompletedHfFsQueryTelemetry {
+	if (!Number.isSafeInteger(requestedCount) || requestedCount < 1 || requestedCount > HF_FS_BATCH_MAX_OPERATIONS) {
+		throw new Error('Invalid hf_fs telemetry requested operation count');
+	}
+	if (items.length !== requestedCount) {
+		throw new Error('Completed hf_fs telemetry requires one result per requested operation');
+	}
+
+	const errorCounts: Record<HfFsErrorClass, number> = { ...EMPTY_ERROR_COUNTS };
+	const operationErrors: HfFsOperationErrorTelemetry[] = [];
+	const observedIndexes = new Set<number>();
+	let successCount = 0;
+
+	for (const item of items) {
+		if (
+			!Number.isSafeInteger(item.index) ||
+			item.index < 0 ||
+			item.index >= requestedCount ||
+			observedIndexes.has(item.index)
+		) {
+			throw new Error('Completed hf_fs telemetry requires unique in-range operation indexes');
+		}
+		observedIndexes.add(item.index);
+		if (item.status === 'success') {
+			successCount += 1;
+			continue;
+		}
+		errorCounts[hfFsErrorClass(item.error.code)] += 1;
+		operationErrors.push({
+			index: item.index,
+			code: item.error.code,
+			...(item.error.suggestedOperation ? { suggestedOperation: item.error.suggestedOperation } : {}),
+		});
+	}
+
+	const batchOutcome = successCount === requestedCount ? 'complete' : successCount === 0 ? 'none_succeeded' : 'partial';
+
+	return {
+		hfFsReportingSchema: HF_FS_REPORTING_SCHEMA,
+		hfFsBatchOutcome: batchOutcome,
+		hfFsOperationsRequested: requestedCount,
+		hfFsOperationsCompleted: items.length,
+		hfFsOperationsSucceeded: successCount,
+		hfFsRequestErrorCount: errorCounts.request,
+		hfFsTargetErrorCount: errorCounts.target,
+		hfFsPolicyLimitErrorCount: errorCounts.policy_limit,
+		hfFsServiceErrorCount: errorCounts.service,
+		hfFsOperationErrorsJson: JSON.stringify(operationErrors),
+	};
+}
+
+export function summarizeInterruptedHfFsBatch(
+	requestedCount: number,
+	outcome: Extract<HfFsBatchOutcome, 'failed' | 'cancelled'>
+): HfFsQueryTelemetry {
+	if (!Number.isSafeInteger(requestedCount) || requestedCount < 1 || requestedCount > HF_FS_BATCH_MAX_OPERATIONS) {
+		throw new Error('Invalid interrupted hf_fs telemetry requested operation count');
+	}
+	return {
+		hfFsReportingSchema: HF_FS_REPORTING_SCHEMA,
+		hfFsBatchOutcome: outcome,
+		hfFsOperationsRequested: requestedCount,
+		hfFsOperationErrorsJson: '[]',
+	};
+}

--- a/packages/app/src/server/utils/query-logger.ts
+++ b/packages/app/src/server/utils/query-logger.ts
@@ -3,6 +3,7 @@ import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
 import { SERVER_BUILD_SHA, SERVER_VERSION } from '../server-build-info.js';
 import { redactHfTokens, redactSensitiveLogValues } from './hf-dataset-transport.js';
+import type { HfFsQueryTelemetry } from './hf-fs-telemetry.js';
 
 // Feature flags: enable/disable per-log-type; defaults to true
 const QUERY_LOGS_ENABLED = (process.env.LOG_QUERY_EVENTS ?? 'true').toLowerCase() === 'true';
@@ -16,7 +17,7 @@ const __dirname = dirname(__filename);
 /**
  * Structure for query logs - consistent fields for HF dataset viewer
  */
-interface QueryLogEntry {
+interface QueryLogEntry extends Partial<HfFsQueryTelemetry> {
 	mcpServerSessionId: string; // MCP Server to Dataset connection
 	serverVersion: string;
 	serverBuildSha: string;
@@ -43,7 +44,7 @@ interface QueryLogEntry {
 	errorMessage?: string | null;
 }
 
-export interface QueryLoggerOptions {
+export interface QueryLoggerOptions extends Partial<HfFsQueryTelemetry> {
 	clientSessionId?: string;
 	requestId?: string;
 	protocolEra?: 'legacy' | 'modern';
@@ -253,6 +254,16 @@ function logQueryEvent(
 		durationMs: normalizedDurationMs,
 		success: options?.success ?? true,
 		errorMessage: normalizedError,
+		hfFsReportingSchema: options?.hfFsReportingSchema,
+		hfFsBatchOutcome: options?.hfFsBatchOutcome,
+		hfFsOperationsRequested: options?.hfFsOperationsRequested,
+		hfFsOperationsCompleted: options?.hfFsOperationsCompleted,
+		hfFsOperationsSucceeded: options?.hfFsOperationsSucceeded,
+		hfFsRequestErrorCount: options?.hfFsRequestErrorCount,
+		hfFsTargetErrorCount: options?.hfFsTargetErrorCount,
+		hfFsPolicyLimitErrorCount: options?.hfFsPolicyLimitErrorCount,
+		hfFsServiceErrorCount: options?.hfFsServiceErrorCount,
+		hfFsOperationErrorsJson: options?.hfFsOperationErrorsJson,
 	});
 }
 

--- a/packages/app/src/server/web-server.ts
+++ b/packages/app/src/server/web-server.ts
@@ -8,6 +8,7 @@ import type { TransportInfo } from '../shared/transport-info.js';
 import { logger } from './utils/logger.js';
 import type { BaseTransport } from './transport/base-transport.js';
 import { formatMetricsForAPI } from '../shared/transport-metrics.js';
+import { getHfFsLiveMetrics } from './utils/hf-fs-live-metrics.js';
 import { CORS_ALLOWED_ORIGINS, CORS_EXPOSED_HEADERS } from '../shared/constants.js';
 import { apiMetrics } from './utils/api-metrics.js';
 import { gradioMetrics } from './utils/gradio-metrics.js';
@@ -392,6 +393,7 @@ export class WebServer {
 
 				// Format for API response
 				const formattedMetrics = formatMetricsForAPI(metrics, this.transportInfo.transport, isStateless, sessions);
+				formattedMetrics.hfFsMetrics = getHfFsLiveMetrics();
 
 				// Add API metrics if in external API mode
 				if (this.transportInfo.externalApiMode) {

--- a/packages/app/src/shared/transport-metrics.ts
+++ b/packages/app/src/shared/transport-metrics.ts
@@ -142,6 +142,7 @@ interface ClientMetrics {
 	activeConnections: number;
 	totalConnections: number;
 	toolCallCount: number;
+	toolCallErrorCount: number;
 	newIpCount: number;
 	anonCount: number;
 	uniqueAuthCount: number;
@@ -304,6 +305,8 @@ export interface TransportMetricsResponse {
 		};
 	};
 
+	hfFsMetrics?: HfFsLiveMetricsResponse;
+
 	clients: Array<{
 		name: string;
 		version: string;
@@ -314,6 +317,8 @@ export interface TransportMetricsResponse {
 		activeConnections: number;
 		totalConnections: number;
 		toolCallCount: number;
+		toolCallErrorCount: number;
+		toolCallErrorRate: number;
 		newIpCount: number;
 		anonCount: number;
 		uniqueAuthCount: number;
@@ -373,6 +378,27 @@ export interface TransportMetricsResponse {
 	gradioCacheMetrics?: GradioCacheMetrics;
 }
 
+export interface HfFsLiveMetricsResponse {
+	reportingSchema: 'hf_fs_batch_v1';
+	batches: {
+		total: number;
+		complete: number;
+		partial: number;
+		noneSucceeded: number;
+		failed: number;
+		cancelled: number;
+	};
+	operations: {
+		completed: number;
+		succeeded: number;
+		requestErrors: number;
+		targetErrors: number;
+		policyLimitErrors: number;
+		serviceErrors: number;
+	};
+	lastUpdated: string | null;
+}
+
 /**
  * Convert internal metrics to API response format
  */
@@ -413,6 +439,7 @@ export function formatMetricsForAPI(
 		},
 		clients: Array.from(metrics.clients.values()).map((client) => ({
 			...client,
+			toolCallErrorRate: client.toolCallCount > 0 ? (client.toolCallErrorCount / client.toolCallCount) * 100 : 0,
 			firstSeen: client.firstSeen.toISOString(),
 			lastSeen: client.lastSeen.toISOString(),
 			protocols: Array.from(client.protocols.values())
@@ -902,6 +929,7 @@ export class MetricsCounter {
 				activeConnections: 1,
 				totalConnections: 1,
 				toolCallCount: 0,
+				toolCallErrorCount: 0,
 				newIpCount: 0,
 				anonCount: 0,
 				uniqueAuthCount: 0,
@@ -993,11 +1021,14 @@ export class MetricsCounter {
 			clientMethodMetrics.count++;
 
 			// If this is a tool call, increment the client's tool call count
-			if (method.startsWith('tools/call:')) {
+			if (method === 'tools/call' || method.startsWith('tools/call:')) {
 				const clientKey = getClientKey(clientInfo.name, clientInfo.version);
 				const clientMetrics = this.metrics.clients.get(clientKey);
 				if (clientMetrics) {
 					clientMetrics.toolCallCount++;
+					if (isError) {
+						clientMetrics.toolCallErrorCount++;
+					}
 				}
 			}
 		}

--- a/packages/app/src/web/components/HfFsLiveMetricsCard.tsx
+++ b/packages/app/src/web/components/HfFsLiveMetricsCard.tsx
@@ -1,0 +1,86 @@
+import type { HfFsLiveMetricsResponse } from '../../shared/transport-metrics.js';
+import { formatCompactNumber } from '../lib/dashboard-utils';
+import { SectionHeader } from './DashboardPrimitives';
+import { Badge } from './ui/badge';
+import { Card, CardContent } from './ui/card';
+
+interface HfFsLiveMetricsCardProps {
+	metrics: HfFsLiveMetricsResponse;
+}
+
+function formatUpdated(timestamp: string): string {
+	const elapsedSeconds = Math.max(0, Math.floor((Date.now() - new Date(timestamp).getTime()) / 1000));
+	if (elapsedSeconds < 60) return 'just now';
+	const elapsedMinutes = Math.floor(elapsedSeconds / 60);
+	if (elapsedMinutes < 60) return `${elapsedMinutes.toString()}m ago`;
+	const elapsedHours = Math.floor(elapsedMinutes / 60);
+	return `${elapsedHours.toString()}h ago`;
+}
+
+export function HfFsLiveMetricsCard({ metrics }: HfFsLiveMetricsCardProps) {
+	const operationErrors =
+		metrics.operations.requestErrors +
+		metrics.operations.targetErrors +
+		metrics.operations.policyLimitErrors +
+		metrics.operations.serviceErrors;
+	const operationSuccessRate =
+		metrics.operations.completed > 0 ? (metrics.operations.succeeded / metrics.operations.completed) * 100 : undefined;
+	const nonCompleteBatches =
+		metrics.batches.partial + metrics.batches.noneSucceeded + metrics.batches.failed + metrics.batches.cancelled;
+
+	return (
+		<Card>
+			<CardContent className="space-y-4">
+				<SectionHeader
+					title="hf_fs live"
+					description="Process-local batch and operation outcomes since this server started."
+					aside={
+						<Badge variant="outline">
+							{metrics.lastUpdated ? `Updated ${formatUpdated(metrics.lastUpdated)}` : 'Waiting for first call'}
+						</Badge>
+					}
+				/>
+				<div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+					<div className="rounded-xl border bg-muted/25 p-3">
+						<p className="text-xs font-medium text-muted-foreground">Batches</p>
+						<p className="mt-1 font-mono text-xl font-semibold">{formatCompactNumber(metrics.batches.total)}</p>
+						<p className="mt-1 text-xs text-muted-foreground">
+							{metrics.batches.complete} complete · {metrics.batches.partial} partial
+						</p>
+					</div>
+					<div className="rounded-xl border bg-muted/25 p-3">
+						<p className="text-xs font-medium text-muted-foreground">Completed operations</p>
+						<p className="mt-1 font-mono text-xl font-semibold">{formatCompactNumber(metrics.operations.completed)}</p>
+						<p className="mt-1 text-xs text-muted-foreground">
+							{formatCompactNumber(metrics.operations.succeeded)} succeeded · {formatCompactNumber(operationErrors)}{' '}
+							errors
+						</p>
+					</div>
+					<div className="rounded-xl border bg-muted/25 p-3">
+						<p className="text-xs font-medium text-muted-foreground">Operation success</p>
+						<p className="mt-1 font-mono text-xl font-semibold">
+							{operationSuccessRate === undefined ? '—' : `${operationSuccessRate.toFixed(1)}%`}
+						</p>
+						<p className="mt-1 text-xs text-muted-foreground">Completed operations only</p>
+					</div>
+					<div className="rounded-xl border bg-muted/25 p-3">
+						<p className="text-xs font-medium text-muted-foreground">Non-complete batches</p>
+						<p className="mt-1 font-mono text-xl font-semibold">{formatCompactNumber(nonCompleteBatches)}</p>
+						<p className="mt-1 text-xs text-muted-foreground">
+							{metrics.batches.noneSucceeded} zero-success · {metrics.batches.failed} failed ·{' '}
+							{metrics.batches.cancelled} cancelled
+						</p>
+					</div>
+				</div>
+				<div className="flex flex-wrap gap-2 text-xs">
+					<Badge variant="secondary">Request errors · {metrics.operations.requestErrors}</Badge>
+					<Badge variant="secondary">Target errors · {metrics.operations.targetErrors}</Badge>
+					<Badge variant="outline">Policy/limit · {metrics.operations.policyLimitErrors}</Badge>
+					<Badge variant={metrics.operations.serviceErrors > 0 ? 'destructive' : 'outline'}>
+						Service errors · {metrics.operations.serviceErrors}
+					</Badge>
+				</div>
+			</CardContent>
+		</Card>
+	);
+}

--- a/packages/app/src/web/components/StatelessTransportMetrics.tsx
+++ b/packages/app/src/web/components/StatelessTransportMetrics.tsx
@@ -7,6 +7,7 @@ import { createSortableHeader } from './data-table-utils';
 import { MetricTile, SectionHeader } from './DashboardPrimitives';
 import { formatCompactNumber } from '../lib/dashboard-utils';
 import type { TransportMetricsResponse } from '../../shared/transport-metrics.js';
+import { HfFsLiveMetricsCard } from './HfFsLiveMetricsCard';
 
 type ClientMetric = TransportMetricsResponse['clients'][number];
 type ClientProtocolMetric = ClientMetric['protocols'][number];
@@ -15,6 +16,8 @@ type ClientProtocolData = Omit<
 	'protocols' | 'requestCount' | 'toolCallCount' | 'firstSeen' | 'lastSeen'
 > & {
 	protocol: ClientProtocolMetric;
+	sortKey: string;
+	clientWideToolCallCount: number;
 	requestCount: number;
 	toolCallCount: number;
 	firstSeen: string;
@@ -80,10 +83,12 @@ interface StatelessTransportMetricsProps {
 
 export function StatelessTransportMetrics({ metrics }: StatelessTransportMetricsProps) {
 	const clientData: ClientProtocolData[] = metrics.clients.flatMap((client) => {
-		const { protocols, ...clientTotals } = client;
+		const { protocols, toolCallCount: clientWideToolCallCount, ...clientTotals } = client;
 		return protocols.map((protocol) => ({
 			...clientTotals,
 			protocol,
+			sortKey: `${client.name}\u0000${client.version}\u0000${protocol.era}\u0000${protocol.version}`,
+			clientWideToolCallCount,
 			requestCount: protocol.requestCount,
 			toolCallCount: protocol.toolCallCount,
 			firstSeen: protocol.firstSeen,
@@ -98,6 +103,7 @@ export function StatelessTransportMetrics({ metrics }: StatelessTransportMetrics
 		.filter((method) => method.method === 'tools/call' || method.method.startsWith('tools/call:'))
 		.reduce((sum, method) => sum + method.count, 0);
 	const recentClients = metrics.clients.filter((client) => isRecentlyActive(client.lastSeen)).length;
+	const hfFsMetrics = metrics.hfFsMetrics;
 	const protocolFilterOptions = Array.from(
 		new Map(
 			clientData.map((client) => {
@@ -110,7 +116,8 @@ export function StatelessTransportMetrics({ metrics }: StatelessTransportMetrics
 	// Define columns for exact client/protocol combinations.
 	const createClientColumns = (): ColumnDef<ClientProtocolData>[] => [
 		{
-			accessorKey: 'name',
+			id: 'name',
+			accessorFn: (client) => client.sortKey,
 			header: createSortableHeader('Client'),
 			cell: ({ row }) => {
 				const client = row.original;
@@ -148,6 +155,28 @@ export function StatelessTransportMetrics({ metrics }: StatelessTransportMetrics
 			accessorKey: 'toolCallCount',
 			header: createSortableHeader('Tool Calls', 'right'),
 			cell: ({ row }) => <div className="text-right font-mono text-sm">{row.getValue<number>('toolCallCount')}</div>,
+		},
+		{
+			accessorKey: 'toolCallErrorRate',
+			header: createSortableHeader('Tool Error Rate', 'right'),
+			cell: ({ row }) => {
+				const client = row.original;
+				if (client.clientWideToolCallCount === 0) {
+					return <div className="text-right text-muted-foreground">—</div>;
+				}
+				return (
+					<div
+						className="text-right font-mono text-sm"
+						title={`${client.toolCallErrorCount.toLocaleString()} failed of ${client.clientWideToolCallCount.toLocaleString()} client tool calls across all protocol versions`}
+					>
+						{client.toolCallErrorRate > 0 ? (
+							<span className="text-red-600 dark:text-red-400">{client.toolCallErrorRate.toFixed(1)}%</span>
+						) : (
+							'0%'
+						)}
+					</div>
+				);
+			},
 		},
 		{
 			accessorKey: 'newIpCount',
@@ -273,6 +302,8 @@ export function StatelessTransportMetrics({ metrics }: StatelessTransportMetrics
 				/>
 			</div>
 
+			{hfFsMetrics ? <HfFsLiveMetricsCard metrics={hfFsMetrics} /> : null}
+
 			<Card>
 				<CardContent>
 					<div className="grid gap-4 text-sm sm:grid-cols-2 lg:grid-cols-4">
@@ -309,7 +340,7 @@ export function StatelessTransportMetrics({ metrics }: StatelessTransportMetrics
 				<CardContent>
 					<SectionHeader
 						title="Client implementations"
-						description="One row per implementation and exact protocol version, with protocol-attributed requests and tool calls."
+						description="One row per implementation and exact protocol version. Error rate is client-wide across protocol versions."
 					/>
 					<DataTable
 						columns={createClientColumns()}
@@ -322,7 +353,7 @@ export function StatelessTransportMetrics({ metrics }: StatelessTransportMetrics
 							options: protocolFilterOptions,
 						}}
 						pageSize={50}
-						defaultSorting={[{ id: 'lastSeen', desc: true }]}
+						defaultSorting={[{ id: 'name', desc: false }]}
 					/>
 				</CardContent>
 			</Card>

--- a/packages/app/src/web/components/StdioTransportMetrics.tsx
+++ b/packages/app/src/web/components/StdioTransportMetrics.tsx
@@ -8,6 +8,7 @@ import { useSessionCache } from '../hooks/useSessionCache';
 import type { TransportMetricsResponse } from '../../shared/transport-metrics.js';
 import { MetricTile, SectionHeader } from './DashboardPrimitives';
 import { formatCompactNumber } from '../lib/dashboard-utils';
+import { HfFsLiveMetricsCard } from './HfFsLiveMetricsCard';
 
 type SessionData = {
 	id: string;
@@ -193,6 +194,7 @@ export function StdioTransportMetrics({ metrics }: StdioTransportMetricsProps) {
 					tone="amber"
 				/>
 			</div>
+			{metrics.hfFsMetrics ? <HfFsLiveMetricsCard metrics={metrics.hfFsMetrics} /> : null}
 			<Card>
 				<CardContent>
 					<SectionHeader

--- a/packages/app/src/web/components/data-table.tsx
+++ b/packages/app/src/web/components/data-table.tsx
@@ -1,7 +1,13 @@
 'use client';
 
 import * as React from 'react';
-import type { ColumnDef, ColumnFiltersState, SortingState, VisibilityState } from '@tanstack/react-table';
+import type {
+	ColumnDef,
+	ColumnFiltersState,
+	PaginationState,
+	SortingState,
+	VisibilityState,
+} from '@tanstack/react-table';
 import {
 	flexRender,
 	getCoreRowModel,
@@ -51,30 +57,42 @@ export function DataTable<TData, TValue>({
 	const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>([]);
 	const [columnVisibility, setColumnVisibility] = React.useState<VisibilityState>(defaultColumnVisibility);
 	const [rowSelection, setRowSelection] = React.useState({});
+	const [pagination, setPagination] = React.useState<PaginationState>({ pageIndex: 0, pageSize });
+
+	React.useEffect(() => {
+		setPagination((current) => {
+			const maximumPageIndex = Math.max(0, Math.ceil(data.length / current.pageSize) - 1);
+			return current.pageIndex > maximumPageIndex ? { ...current, pageIndex: maximumPageIndex } : current;
+		});
+	}, [data.length]);
 
 	// TanStack Table intentionally manages mutable callbacks; React Compiler skips this component safely.
 	// eslint-disable-next-line react-hooks/incompatible-library
 	const table = useReactTable({
 		data,
 		columns,
-		onSortingChange: setSorting,
-		onColumnFiltersChange: setColumnFilters,
+		onSortingChange: (updater) => {
+			setSorting(updater);
+			setPagination((current) => ({ ...current, pageIndex: 0 }));
+		},
+		onColumnFiltersChange: (updater) => {
+			setColumnFilters(updater);
+			setPagination((current) => ({ ...current, pageIndex: 0 }));
+		},
+		onPaginationChange: setPagination,
 		getCoreRowModel: getCoreRowModel(),
 		getPaginationRowModel: getPaginationRowModel(),
 		getSortedRowModel: getSortedRowModel(),
 		getFilteredRowModel: getFilteredRowModel(),
 		onColumnVisibilityChange: setColumnVisibility,
 		onRowSelectionChange: setRowSelection,
-		initialState: {
-			pagination: {
-				pageSize: pageSize,
-			},
-		},
+		autoResetPageIndex: false,
 		state: {
 			sorting,
 			columnFilters,
 			columnVisibility,
 			rowSelection,
+			pagination,
 		},
 	});
 
@@ -178,6 +196,9 @@ export function DataTable<TData, TValue>({
 			<div className="flex items-center justify-end space-x-2 pt-3">
 				<div className="text-muted-foreground flex-1 text-sm">
 					{table.getFilteredRowModel().rows.length} row(s) total.
+				</div>
+				<div className="text-sm text-muted-foreground">
+					Page {table.getState().pagination.pageIndex + 1} of {Math.max(1, table.getPageCount())}
 				</div>
 				<div className="space-x-2">
 					<Button

--- a/packages/app/test/server/hf-fs-wiring.test.ts
+++ b/packages/app/test/server/hf-fs-wiring.test.ts
@@ -6,6 +6,11 @@ import { createServerFactory } from '../../src/server/mcp-server.js';
 import { McpApiClient } from '../../src/server/utils/mcp-api-client.js';
 import type { TransportInfo } from '../../src/shared/transport-info.js';
 
+const queryLoggerMocks = vi.hoisted(() => ({
+	logToolQuery: vi.fn(),
+	logGradioEvent: vi.fn(),
+}));
+
 vi.mock('@huggingface/hub', async (importOriginal) => {
 	const actual = await importOriginal<typeof import('@huggingface/hub')>();
 	return {
@@ -14,6 +19,8 @@ vi.mock('@huggingface/hub', async (importOriginal) => {
 		pathsInfo: vi.fn(),
 	};
 });
+
+vi.mock('../../src/server/utils/query-logger.js', () => queryLoggerMocks);
 
 const transportInfo: TransportInfo = {
 	transport: 'streamableHttpJson',
@@ -27,6 +34,83 @@ describe('hf_fs MCP wiring', () => {
 	beforeEach(() => {
 		vi.mocked(pathsInfo).mockReset();
 		vi.mocked(downloadFile).mockReset();
+		queryLoggerMocks.logToolQuery.mockReset();
+		queryLoggerMocks.logGradioEvent.mockReset();
+	});
+
+	it('logs bounded operation errors and aggregate classes for a partial batch', async () => {
+		const apiClient = new McpApiClient({ type: 'static' }, transportInfo);
+		const { server } = await createServerFactory(apiClient)({}, { builtInTools: [], spaceTools: [] }, true, {});
+		const client = new Client({ name: 'hf-fs-wiring-test', version: '1.0.0' });
+		const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+		await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+
+		try {
+			await client.callTool({
+				name: 'hf_fs',
+				arguments: {
+					operations: [
+						{ cmd: 'stat', args: ['hf://bogus'] },
+						{ cmd: 'stat', args: ['hf://models'] },
+					],
+				},
+			});
+
+			expect(queryLoggerMocks.logToolQuery).toHaveBeenCalledOnce();
+			expect(queryLoggerMocks.logToolQuery.mock.calls[0]?.[3]).toMatchObject({
+				totalResults: 2,
+				resultsShared: 1,
+				success: true,
+				hfFsReportingSchema: 'hf_fs_batch_v1',
+				hfFsBatchOutcome: 'partial',
+				hfFsOperationsRequested: 2,
+				hfFsOperationsCompleted: 2,
+				hfFsOperationsSucceeded: 1,
+				hfFsRequestErrorCount: 1,
+				hfFsTargetErrorCount: 0,
+				hfFsPolicyLimitErrorCount: 0,
+				hfFsServiceErrorCount: 0,
+				hfFsOperationErrorsJson: '[{"index":0,"code":"HF_FS_INVALID_ARGUMENT"}]',
+			});
+		} finally {
+			await client.close();
+			await server.close();
+		}
+	});
+
+	it('logs an interrupted batch without inventing operation outcomes', async () => {
+		vi.mocked(pathsInfo).mockResolvedValueOnce([{ path: 'image.png', type: 'file', size: 3 }]);
+		vi.mocked(downloadFile).mockRejectedValueOnce(new Error('unexpected private provider detail'));
+		const apiClient = new McpApiClient({ type: 'static' }, transportInfo);
+		const { server } = await createServerFactory(apiClient)({}, { builtInTools: [], spaceTools: [] }, true, {});
+		const client = new Client({ name: 'hf-fs-wiring-test', version: '1.0.0' });
+		const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+		await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+
+		try {
+			const result = await client.callTool({
+				name: 'hf_fs',
+				arguments: {
+					operations: [{ cmd: 'attach', args: ['hf://models/org/repo/image.png'] }],
+				},
+			});
+			expect(result.isError).toBe(true);
+
+			expect(queryLoggerMocks.logToolQuery).toHaveBeenCalledOnce();
+			expect(queryLoggerMocks.logToolQuery.mock.calls[0]?.[3]).toMatchObject({
+				success: false,
+				hfFsReportingSchema: 'hf_fs_batch_v1',
+				hfFsBatchOutcome: 'failed',
+				hfFsOperationsRequested: 1,
+				hfFsOperationErrorsJson: '[]',
+				error: expect.any(Error),
+			});
+			expect(queryLoggerMocks.logToolQuery.mock.calls[0]?.[3]).not.toHaveProperty('hfFsOperationsCompleted');
+			expect(queryLoggerMocks.logToolQuery.mock.calls[0]?.[3]).not.toHaveProperty('hfFsOperationsSucceeded');
+		} finally {
+			await client.close();
+			await server.close();
+		}
 	});
 
 	it('returns fixed recovery metadata for deterministic compatibility errors', async () => {

--- a/packages/app/test/server/utils/hf-fs-live-metrics.test.ts
+++ b/packages/app/test/server/utils/hf-fs-live-metrics.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+	getHfFsLiveMetrics,
+	recordHfFsLiveMetrics,
+	resetHfFsLiveMetricsForTests,
+} from '../../../src/server/utils/hf-fs-live-metrics.js';
+
+describe('hf_fs live metrics', () => {
+	beforeEach(() => {
+		resetHfFsLiveMetricsForTests();
+	});
+
+	it('aggregates completed and interrupted batches without raw operation data', () => {
+		recordHfFsLiveMetrics({
+			hfFsReportingSchema: 'hf_fs_batch_v1',
+			hfFsBatchOutcome: 'partial',
+			hfFsOperationsRequested: 3,
+			hfFsOperationsCompleted: 3,
+			hfFsOperationsSucceeded: 1,
+			hfFsRequestErrorCount: 1,
+			hfFsTargetErrorCount: 1,
+			hfFsPolicyLimitErrorCount: 0,
+			hfFsServiceErrorCount: 0,
+			hfFsOperationErrorsJson: '[{"index":1,"code":"HF_FS_INVALID_ARGUMENT"}]',
+		});
+		recordHfFsLiveMetrics({
+			hfFsReportingSchema: 'hf_fs_batch_v1',
+			hfFsBatchOutcome: 'failed',
+			hfFsOperationsRequested: 1,
+			hfFsOperationErrorsJson: '[]',
+		});
+
+		expect(getHfFsLiveMetrics()).toEqual({
+			reportingSchema: 'hf_fs_batch_v1',
+			batches: {
+				total: 2,
+				complete: 0,
+				partial: 1,
+				noneSucceeded: 0,
+				failed: 1,
+				cancelled: 0,
+			},
+			operations: {
+				completed: 3,
+				succeeded: 1,
+				requestErrors: 1,
+				targetErrors: 1,
+				policyLimitErrors: 0,
+				serviceErrors: 0,
+			},
+			lastUpdated: expect.any(String),
+		});
+	});
+
+	it('returns an isolated snapshot', () => {
+		const snapshot = getHfFsLiveMetrics();
+		snapshot.batches.total = 100;
+		expect(getHfFsLiveMetrics().batches.total).toBe(0);
+	});
+});

--- a/packages/app/test/server/utils/hf-fs-telemetry.test.ts
+++ b/packages/app/test/server/utils/hf-fs-telemetry.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest';
+import type { HfFsBatchExecutionItem } from '@llmindset/hf-mcp';
+import {
+	HF_FS_REPORTING_SCHEMA,
+	summarizeCompletedHfFsBatch,
+	summarizeInterruptedHfFsBatch,
+} from '../../../src/server/utils/hf-fs-telemetry.js';
+
+function success(index: number): HfFsBatchExecutionItem {
+	return {
+		index,
+		status: 'success',
+		executionResult: {
+			op: 'stat',
+			uri: 'hf://models',
+			exists: true,
+			type: 'namespace',
+		},
+	};
+}
+
+function failure(
+	index: number,
+	code: 'HF_FS_INVALID_ARGUMENT' | 'HF_FS_NOT_FOUND' | 'HF_FS_IMAGE_CONTENT_DISABLED' | 'HF_FS_ATTACHMENT_INTEGRITY'
+): HfFsBatchExecutionItem {
+	return {
+		index,
+		status: 'error',
+		error: {
+			code,
+			message: 'sensitive provider-derived detail',
+			recovery: 'fixed recovery guidance',
+			retryable: false,
+			suggestedOperation: 'stat',
+		},
+	};
+}
+
+describe('hf_fs query telemetry', () => {
+	it('summarizes a complete batch', () => {
+		expect(summarizeCompletedHfFsBatch(2, [success(0), success(1)])).toEqual({
+			hfFsReportingSchema: HF_FS_REPORTING_SCHEMA,
+			hfFsBatchOutcome: 'complete',
+			hfFsOperationsRequested: 2,
+			hfFsOperationsCompleted: 2,
+			hfFsOperationsSucceeded: 2,
+			hfFsRequestErrorCount: 0,
+			hfFsTargetErrorCount: 0,
+			hfFsPolicyLimitErrorCount: 0,
+			hfFsServiceErrorCount: 0,
+			hfFsOperationErrorsJson: '[]',
+		});
+	});
+
+	it('summarizes partial failures by stable class and bounded operation index', () => {
+		const telemetry = summarizeCompletedHfFsBatch(5, [
+			success(0),
+			failure(1, 'HF_FS_INVALID_ARGUMENT'),
+			failure(2, 'HF_FS_NOT_FOUND'),
+			failure(3, 'HF_FS_IMAGE_CONTENT_DISABLED'),
+			failure(4, 'HF_FS_ATTACHMENT_INTEGRITY'),
+		]);
+
+		expect(telemetry).toMatchObject({
+			hfFsBatchOutcome: 'partial',
+			hfFsOperationsRequested: 5,
+			hfFsOperationsCompleted: 5,
+			hfFsOperationsSucceeded: 1,
+			hfFsRequestErrorCount: 1,
+			hfFsTargetErrorCount: 1,
+			hfFsPolicyLimitErrorCount: 1,
+			hfFsServiceErrorCount: 1,
+		});
+		expect(JSON.parse(telemetry.hfFsOperationErrorsJson)).toEqual([
+			{ index: 1, code: 'HF_FS_INVALID_ARGUMENT', suggestedOperation: 'stat' },
+			{ index: 2, code: 'HF_FS_NOT_FOUND', suggestedOperation: 'stat' },
+			{ index: 3, code: 'HF_FS_IMAGE_CONTENT_DISABLED', suggestedOperation: 'stat' },
+			{ index: 4, code: 'HF_FS_ATTACHMENT_INTEGRITY', suggestedOperation: 'stat' },
+		]);
+		expect(telemetry.hfFsOperationErrorsJson).not.toContain('sensitive provider-derived detail');
+		expect(telemetry.hfFsOperationErrorsJson).not.toContain('fixed recovery guidance');
+	});
+
+	it('distinguishes an all-classified-error batch from an interrupted batch', () => {
+		expect(summarizeCompletedHfFsBatch(1, [failure(0, 'HF_FS_NOT_FOUND')])).toMatchObject({
+			hfFsBatchOutcome: 'none_succeeded',
+			hfFsOperationsCompleted: 1,
+			hfFsOperationsSucceeded: 0,
+			hfFsTargetErrorCount: 1,
+		});
+		expect(summarizeInterruptedHfFsBatch(3, 'failed')).toEqual({
+			hfFsReportingSchema: HF_FS_REPORTING_SCHEMA,
+			hfFsBatchOutcome: 'failed',
+			hfFsOperationsRequested: 3,
+			hfFsOperationErrorsJson: '[]',
+		});
+		expect(summarizeInterruptedHfFsBatch(3, 'cancelled')).toMatchObject({
+			hfFsBatchOutcome: 'cancelled',
+		});
+	});
+
+	it('rejects inconsistent completed-batch counts', () => {
+		expect(() => summarizeCompletedHfFsBatch(2, [success(0)])).toThrow(
+			'Completed hf_fs telemetry requires one result per requested operation'
+		);
+		expect(() => summarizeCompletedHfFsBatch(2, [success(0), success(0)])).toThrow(
+			'Completed hf_fs telemetry requires unique in-range operation indexes'
+		);
+	});
+});

--- a/packages/app/test/server/web-server.test.ts
+++ b/packages/app/test/server/web-server.test.ts
@@ -1,10 +1,11 @@
 import { createServer, type Server } from 'node:http';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { WebServer } from '../../src/server/web-server.js';
 import type { BaseTransport, SessionMetadata } from '../../src/server/transport/base-transport.js';
 import { MetricsCounter } from '../../src/shared/transport-metrics.js';
 import { SERVER_CARD_PATH } from '../../src/server/server-card.js';
 import { createMetricsPageAuth, METRICS_PAGE_AUTH_COOKIE_NAME } from '../../src/server/utils/metrics-page-auth.js';
+import { recordHfFsLiveMetrics, resetHfFsLiveMetricsForTests } from '../../src/server/utils/hf-fs-live-metrics.js';
 
 const METRICS_PASSWORD = 'test metrics password & secret';
 
@@ -39,6 +40,10 @@ describe('WebServer', () => {
 	const servers: Server[] = [];
 	const webServers: WebServer[] = [];
 
+	beforeEach(() => {
+		resetHfFsLiveMetricsForTests();
+	});
+
 	afterEach(async () => {
 		await Promise.allSettled(webServers.map((server) => server.stop()));
 		await Promise.allSettled(servers.map((server) => close(server)));
@@ -64,6 +69,18 @@ describe('WebServer', () => {
 	});
 
 	it('omits analytics session details from stateless transport metrics', async () => {
+		recordHfFsLiveMetrics({
+			hfFsReportingSchema: 'hf_fs_batch_v1',
+			hfFsBatchOutcome: 'complete',
+			hfFsOperationsRequested: 2,
+			hfFsOperationsCompleted: 2,
+			hfFsOperationsSucceeded: 2,
+			hfFsRequestErrorCount: 0,
+			hfFsTargetErrorCount: 0,
+			hfFsPolicyLimitErrorCount: 0,
+			hfFsServiceErrorCount: 0,
+			hfFsOperationErrorsJson: '[]',
+		});
 		const webServer = new WebServer();
 		webServers.push(webServer);
 		const getSessions = vi.fn(() => [testSession()]);
@@ -81,10 +98,17 @@ describe('WebServer', () => {
 		await webServer.start(0);
 
 		const response = await fetch(`http://localhost:${webServerPort(webServer).toString()}/api/transport-metrics`);
-		const body = (await response.json()) as { sessions?: unknown[] };
+		const body = (await response.json()) as {
+			sessions?: unknown[];
+			hfFsMetrics?: { batches: { total: number }; operations: { completed: number; succeeded: number } };
+		};
 
 		expect(response.status).toBe(200);
 		expect(body.sessions).toEqual([]);
+		expect(body.hfFsMetrics).toMatchObject({
+			batches: { total: 1 },
+			operations: { completed: 2, succeeded: 2 },
+		});
 		expect(getSessions).not.toHaveBeenCalled();
 	});
 

--- a/packages/app/test/shared/transport-metrics.test.ts
+++ b/packages/app/test/shared/transport-metrics.test.ts
@@ -111,6 +111,21 @@ describe('MetricsCounter', () => {
 		);
 	});
 
+	it('reports client-wide tool-call error rates without counting non-tool method errors', () => {
+		const metrics = new MetricsCounter();
+		const client = { name: 'batch-client', version: '1.0.0' };
+		metrics.associateSessionWithClient(client);
+		metrics.trackMethod('tools/call:hf_fs', 10, false, client);
+		metrics.trackMethod('tools/call:hf_fs', 20, true, client);
+		metrics.trackMethod('resources/read:skill://example', 5, true, client);
+
+		expect(formatMetricsForAPI(metrics.getMetrics(), 'streamableHttpJson', true).clients[0]).toMatchObject({
+			toolCallCount: 2,
+			toolCallErrorCount: 1,
+			toolCallErrorRate: 50,
+		});
+	});
+
 	it('bounds unexpected protocol-version cardinality', () => {
 		const metrics = new MetricsCounter();
 		for (let index = 0; index < 40; index++) {

--- a/packages/mcp/src/hf-fs-errors.test.ts
+++ b/packages/mcp/src/hf-fs-errors.test.ts
@@ -8,6 +8,7 @@ import {
 	HfFsUnsupportedMediaError,
 	classifyHfFsError,
 	formatHfFsRecoveryError,
+	hfFsErrorClass,
 	type HfFsErrorCode,
 } from './hf-fs-errors.js';
 
@@ -104,5 +105,23 @@ describe('hf-fs-errors', () => {
 		expect(classifyHfFsError(Object.assign(new Error('Rate limited'), { statusCode: 429 }))).toBeUndefined();
 		expect(classifyHfFsError(new Error('Provider rejected the request with status 400'))).toBeUndefined();
 		expect(classifyHfFsError('not an error')).toBeUndefined();
+	});
+
+	it.each([
+		['HF_FS_INVALID_ARGUMENT', 'request'],
+		['HF_FS_NOT_FOUND', 'target'],
+		['HF_FS_NOT_A_DIRECTORY', 'request'],
+		['HF_FS_NOT_A_FILE', 'request'],
+		['HF_FS_UNSUPPORTED_OPERATION', 'request'],
+		['HF_FS_ACCESS_DENIED', 'target'],
+		['HF_FS_TEXT_ONLY', 'request'],
+		['HF_FS_IMAGE_ONLY', 'request'],
+		['HF_FS_UNSUPPORTED_MEDIA', 'request'],
+		['HF_FS_IMAGE_TOO_LARGE', 'policy_limit'],
+		['HF_FS_ATTACHMENT_BUDGET_EXCEEDED', 'policy_limit'],
+		['HF_FS_IMAGE_CONTENT_DISABLED', 'policy_limit'],
+		['HF_FS_ATTACHMENT_INTEGRITY', 'service'],
+	] as const)('maps %s to the %s reporting class', (code, errorClass) => {
+		expect(hfFsErrorClass(code)).toBe(errorClass);
 	});
 });

--- a/packages/mcp/src/hf-fs-errors.ts
+++ b/packages/mcp/src/hf-fs-errors.ts
@@ -16,6 +16,30 @@ export const HF_FS_ERROR_CODES = [
 
 export type HfFsErrorCode = (typeof HF_FS_ERROR_CODES)[number];
 
+export const HF_FS_ERROR_CLASSES = ['request', 'target', 'policy_limit', 'service'] as const;
+
+export type HfFsErrorClass = (typeof HF_FS_ERROR_CLASSES)[number];
+
+const HF_FS_ERROR_CLASS_BY_CODE = {
+	HF_FS_INVALID_ARGUMENT: 'request',
+	HF_FS_NOT_FOUND: 'target',
+	HF_FS_NOT_A_DIRECTORY: 'request',
+	HF_FS_NOT_A_FILE: 'request',
+	HF_FS_UNSUPPORTED_OPERATION: 'request',
+	HF_FS_ACCESS_DENIED: 'target',
+	HF_FS_TEXT_ONLY: 'request',
+	HF_FS_IMAGE_ONLY: 'request',
+	HF_FS_UNSUPPORTED_MEDIA: 'request',
+	HF_FS_IMAGE_TOO_LARGE: 'policy_limit',
+	HF_FS_ATTACHMENT_BUDGET_EXCEEDED: 'policy_limit',
+	HF_FS_IMAGE_CONTENT_DISABLED: 'policy_limit',
+	HF_FS_ATTACHMENT_INTEGRITY: 'service',
+} as const satisfies Record<HfFsErrorCode, HfFsErrorClass>;
+
+export function hfFsErrorClass(code: HfFsErrorCode): HfFsErrorClass {
+	return HF_FS_ERROR_CLASS_BY_CODE[code];
+}
+
 export interface HfFsRecoveryError {
 	code: HfFsErrorCode;
 	message: string;


### PR DESCRIPTION
## Summary

- add versioned `hf_fs` batch telemetry with complete/partial/zero-success/failed/cancelled outcomes
- record completed/successful operation counts and bounded request/target/policy-limit/service error counters
- retain failed operation index + fixed `HF_FS_*` code + optional suggested operation without logging response content or dynamic messages
- expose a process-local `hf_fs live` feed on HTTP and STDIO Overview dashboards
- add client-wide tool-call error rates to the client table
- keep table pagination stable across live refreshes and use deterministic client/version/protocol ordering

## Metric semantics

- `hf_fs` operation success uses completed operations as its denominator and includes partial-batch failures
- client-row tool error rate remains transport-level failed tool calls divided by all client tool calls
- interrupted batches do not invent per-operation completion results
- pre-v0.4.11 generic `totalResults` / `resultsShared` behavior is preserved

## Privacy

The new diagnostic field is bounded by the 30-operation batch limit and contains only operation index, a fixed error code, and an optional fixed suggested operation. It does not add response bodies, structured content, error messages, recovery text, URIs, arguments, or attachment data.

## Validation

- `pnpm typecheck`
- `pnpm lint:check`
- `pnpm test` — MCP: 408 tests; App: 495 tests
- `pnpm build`
- `git diff --check`
