### PR TITLE
feat(app): add OpenAI tool bouquet

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ The public Streamable HTTP deployment serves its MCP Server Card at `/mcp/server
 
 The Web Application at `/metrics` reports server status and MCP method metrics. It can be placed behind an optional lightweight shared-password gate using `METRICS_PAGE_PASSWORD`. Browser visits to `/` redirect to the MCP welcome page at `/mcp`. Tool selection is resolved independently for each request from the optional Hugging Face user configuration API and the `bouquet`/`mix` query parameters. Note to security researches and bots, this is intentionally lightweight and not considered sensitive or protected data.
 
+Use `?bouquet=openai` to expose Hub filesystem, repository search and details, dynamic Space, Jobs, and sandbox tools. Jobs, dynamic Space, and sandbox tools require Hugging Face authentication.
+
 ### Running Locally
 
 You can run the MCP Server locally with either `npx` or `docker`. 

--- a/packages/app/src/shared/bouquet-presets.ts
+++ b/packages/app/src/shared/bouquet-presets.ts
@@ -41,6 +41,17 @@ export const BOUQUETS: Record<string, AppSettings> = {
 		builtInTools: [HF_FILES_FLAG, ...TOOL_ID_GROUPS.sandbox, CREATE_REPO_TOOL_ID, HUB_REPO_DETAILS_TOOL_ID],
 		spaceTools: [],
 	},
+	openai: {
+		builtInTools: [
+			HF_FS_TOOL_ID,
+			HUB_REPO_DETAILS_TOOL_ID,
+			REPO_SEARCH_TOOL_ID,
+			DYNAMIC_SPACE_TOOL_ID,
+			HF_JOBS_TOOL_ID,
+			...TOOL_ID_GROUPS.sandbox,
+		],
+		spaceTools: [],
+	},
 	all: {
 		builtInTools: [...ALL_BUILTIN_TOOL_IDS],
 		spaceTools: [],

--- a/packages/app/test/server/utils/tool-selection-strategy.test.ts
+++ b/packages/app/test/server/utils/tool-selection-strategy.test.ts
@@ -193,6 +193,22 @@ describe('BOUQUETS configuration', () => {
 			expect(bouquet.spaceTools).toEqual([]);
 		}
 	});
+
+	it('should expose the OpenAI toolkit through openai bouquet', () => {
+		const bouquet = BOUQUETS.openai;
+		expect(bouquet).toBeDefined();
+		if (bouquet) {
+			expect(bouquet.builtInTools).toEqual([
+				HF_FS_TOOL_ID,
+				HUB_REPO_DETAILS_TOOL_ID,
+				REPO_SEARCH_TOOL_ID,
+				DYNAMIC_SPACE_TOOL_ID,
+				HF_JOBS_TOOL_ID,
+				...TOOL_ID_GROUPS.sandbox,
+			]);
+			expect(bouquet.spaceTools).toEqual([]);
+		}
+	});
 });
 
 describe('ToolSelectionStrategy', () => {
@@ -239,6 +255,17 @@ describe('ToolSelectionStrategy', () => {
 			expect(result.mode).toBe(ToolSelectionMode.BOUQUET_OVERRIDE);
 			expect(result.enabledToolIds).toEqual([...ANONYMOUS_BUILTIN_TOOL_IDS]);
 			expect(result.enabledToolIds).toContain(HF_FS_TOOL_ID);
+		});
+
+		it('should restrict anonymous openai bouquet users to its public tools', async () => {
+			const context: ToolSelectionContext = {
+				headers: { 'x-mcp-bouquet': 'openai' },
+			};
+
+			const result = await strategy.selectTools(context);
+
+			expect(result.mode).toBe(ToolSelectionMode.BOUQUET_OVERRIDE);
+			expect(result.enabledToolIds).toEqual([HF_FS_TOOL_ID, HUB_REPO_DETAILS_TOOL_ID, REPO_SEARCH_TOOL_ID]);
 		});
 
 		it('should use bouquet override for search bouquet', async () => {
@@ -293,6 +320,28 @@ describe('ToolSelectionStrategy', () => {
 			expect(result.mode).toBe(ToolSelectionMode.BOUQUET_OVERRIDE);
 			expect(result.enabledToolIds).toEqual(normalizeBuiltInTools(ALL_BUILTIN_TOOL_IDS));
 			expect(result.reason).toBe('Bouquet override: all');
+		});
+
+		it('should use bouquet override for openai bouquet', async () => {
+			const context: ToolSelectionContext = {
+				headers: { 'x-mcp-bouquet': 'openai' },
+				hfToken: 'test-token',
+			};
+
+			const result = await strategy.selectTools(context);
+
+			expect(result.mode).toBe(ToolSelectionMode.BOUQUET_OVERRIDE);
+			expect(result.enabledToolIds).toEqual([
+				HF_FS_TOOL_ID,
+				HUB_REPO_DETAILS_TOOL_ID,
+				REPO_SEARCH_TOOL_ID,
+				DYNAMIC_SPACE_TOOL_ID,
+				HF_JOBS_TOOL_ID,
+				HF_SANDBOX_TOOL_ID,
+				HF_SANDBOX_EXEC_TOOL_ID,
+				HF_SANDBOX_FS_TOOL_ID,
+			]);
+			expect(result.reason).toBe('Bouquet override: openai');
 		});
 
 		it('should use bouquet override for sandbox bouquet', async () => {


### PR DESCRIPTION
## Summary

- add an `openai` bouquet for OpenAI-oriented MCP clients
- expose `hf_fs`, Hub repository search/details, dynamic Spaces, Jobs, and the complete sandbox tool group
- preserve anonymous visibility filtering so unauthenticated clients only see the public filesystem and repository tools
- document `?bouquet=openai`

## Test results

- `pnpm -C packages/app typecheck`
- `pnpm -C packages/app lint:check`
- `pnpm -C packages/app exec vitest run test/server/utils/tool-selection-strategy.test.ts` (61 passed)
- `pnpm -C packages/mcp build && pnpm -C packages/app test` (512 passed)
- `git diff --check`
