### PR TITLE
fix(stdio): keep serving MCP when the web dashboard port is taken

### DIFF
--- a/packages/app/src/server/application.ts
+++ b/packages/app/src/server/application.ts
@@ -117,7 +117,25 @@ export class Application {
 
 	private async startWebServer(): Promise<void> {
 		// WebServer manages its own lifecycle
-		await this.webServerInstance.start(this.webAppPort);
+		try {
+			await this.webServerInstance.start(this.webAppPort);
+		} catch (error) {
+			// On STDIO the web server is the dashboard, not the transport, and it
+			// starts before the transport is initialized. Letting a listen failure
+			// propagate takes the MCP server down with it: the process exits before
+			// stdin is ever read, so the client sees a server that never answers
+			// `initialize`. The default port is one of the most commonly occupied
+			// on a developer machine, and nothing about serving MCP over stdio
+			// needs it.
+			if (this.transportType === 'stdio') {
+				logger.warn(
+					{ error, port: this.webAppPort },
+					'Web dashboard could not start; continuing with STDIO transport only'
+				);
+				return;
+			}
+			throw error;
+		}
 		logger.info(`Server running at http://localhost:${String(this.webAppPort)}`);
 		logger.info(
 			{ transportType: this.transportType, mode: this.isDev ? 'development with HMR' : 'production' },

--- a/packages/app/test/server/stdio-web-server-failure.test.ts
+++ b/packages/app/test/server/stdio-web-server-failure.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from 'vitest';
+import { Application } from '../../src/server/application.js';
+import type { WebServer } from '../../src/server/web-server.js';
+
+/**
+ * On STDIO the web server is the dashboard, not the transport, and
+ * `Application.start()` starts it before the transport is initialized. A listen
+ * failure there used to propagate out of `start()`, which `stdio.ts` turns into
+ * `process.exit(1)` -- so an occupied port meant the MCP server never read
+ * stdin and the client saw a server that never answered `initialize`.
+ */
+function webServerDouble(startImpl: () => Promise<void>) {
+	return {
+		getApp: () => ({}) as never,
+		setTransportInfo: vi.fn(),
+		setupApiRoutes: vi.fn(),
+		setupStaticFiles: vi.fn(async () => undefined),
+		setTransport: vi.fn(),
+		start: vi.fn(startImpl),
+		stop: vi.fn(async () => undefined),
+	} as unknown as WebServer;
+}
+
+const listenFailure = () => {
+	const error = new Error('listen EADDRINUSE: address already in use :::3000') as NodeJS.ErrnoException;
+	error.code = 'EADDRINUSE';
+	return Promise.reject(error);
+};
+
+describe('web dashboard failure on STDIO', () => {
+	it('keeps serving MCP when the dashboard port is taken', async () => {
+		const webServer = webServerDouble(listenFailure);
+		const app = new Application({
+			transportType: 'stdio',
+			webAppPort: 3000,
+			webServerInstance: webServer,
+		});
+
+		await expect(app.start()).resolves.toBeUndefined();
+		// The transport is initialized after the web server, so reaching it at all
+		// is what proves the failure no longer aborts startup.
+		expect(webServer.setTransport).toHaveBeenCalled();
+	});
+
+	it('still fails for HTTP transports, where the port is the transport', async () => {
+		const app = new Application({
+			transportType: 'streamableHttpJson',
+			webAppPort: 3000,
+			webServerInstance: webServerDouble(listenFailure),
+		});
+
+		await expect(app.start()).rejects.toThrow(/EADDRINUSE/);
+	});
+});


### PR DESCRIPTION
`Application.start()` starts the web server before it initializes the transport, and `WebServer.start()` rejects on any listen error. On STDIO that rejection propagates through `stdio.ts`'s `main().catch()` into `process.exit(1)`, so an occupied dashboard port stops the MCP server before it ever reads stdin — the client sends `initialize` and gets nothing back. The default is `DEFAULT_WEB_APP_PORT` (3000), which is also the default for create-react-app, Next.js dev and most Express templates, so this is reachable on an ordinary developer machine rather than only under contention.

On STDIO the web server is the dashboard, not the transport. This catches the listen failure there, logs it at warn level with the port, and continues, so the transport still initializes. HTTP transports are unchanged: there the port *is* the transport, and a failure is still fatal.

## Reproduction

Against the published `@llmindset/hf-mcp-server@0.4.16`, feeding `initialize` + `tools/list` on stdin:

| dashboard port | exit code | stdout |
|---|---|---|
| held by another process | 1 | nothing |
| free | 0 | `tools/list` returns 5 tools |

stderr on the failing run carries `{"code":"EADDRINUSE",...,"msg":"Server error"}` and nothing else. After this change the occupied-port run exits 0 and returns the same 5 tools, with `Web dashboard could not start; continuing with STDIO transport only` at warn level.

## Test plan

- `npx pnpm@11.9.0 --filter @llmindset/hf-mcp-server exec vitest run test/server/stdio-web-server-failure.test.ts` — 2 passed. With this change reverted the first fails; the second is a control asserting HTTP transports still reject.
- `npx pnpm@11.9.0 test` — 923 passed (409 in `packages/mcp`, 514 in `packages/app`).
- `npx pnpm@11.9.0 typecheck` and `npx pnpm@11.9.0 lint:check` — clean.
