### PR TITLE
Add resource group billing to Jobs and Sandboxes

### DIFF
--- a/packages/mcp/src/jobs/commands/run.ts
+++ b/packages/mcp/src/jobs/commands/run.ts
@@ -17,6 +17,9 @@ export async function runCommand(
 	onProgress?: JobsProgressCallback
 ): Promise<JobsCommandResult> {
 	await notifyJobsProgress(onProgress, { progress: 0, message: 'Submitting job.' });
+	if (args.resource_group_id && !args.namespace) {
+		throw new Error('resource_group_id requires the owning organization as namespace.');
+	}
 
 	// Create job spec from args
 	const jobSpec = createJobSpec({
@@ -28,6 +31,7 @@ export async function runCommand(
 		timeout: args.timeout,
 		hfToken: token,
 		volumes: args.volumes,
+		resourceGroupId: args.resource_group_id,
 	});
 
 	// Submit job
@@ -139,6 +143,7 @@ export async function uvCommand(
 		timeout: args.timeout,
 		detach: args.detach,
 		namespace: args.namespace,
+		resource_group_id: args.resource_group_id,
 		volumes: args.volumes,
 	};
 

--- a/packages/mcp/src/jobs/commands/scheduled.ts
+++ b/packages/mcp/src/jobs/commands/scheduled.ts
@@ -20,6 +20,9 @@ export async function scheduledRunCommand(
 	client: JobsApiClient,
 	token?: string
 ): Promise<JobsCommandResult> {
+	if (args.resource_group_id && !args.namespace) {
+		throw new Error('resource_group_id requires the owning organization as namespace.');
+	}
 	// Create job spec
 	const jobSpec = createJobSpec({
 		image: args.image,
@@ -30,6 +33,7 @@ export async function scheduledRunCommand(
 		timeout: args.timeout,
 		hfToken: token,
 		volumes: args.volumes,
+		resourceGroupId: args.resource_group_id,
 	});
 
 	// Create scheduled job spec
@@ -90,6 +94,7 @@ export async function scheduledUvCommand(
 		timeout: args.timeout,
 		detach: args.detach,
 		namespace: args.namespace,
+		resource_group_id: args.resource_group_id,
 		volumes: args.volumes,
 	};
 

--- a/packages/mcp/src/jobs/commands/utils.ts
+++ b/packages/mcp/src/jobs/commands/utils.ts
@@ -248,6 +248,7 @@ export function createJobSpec(args: {
 	timeout?: string;
 	hfToken?: string;
 	volumes?: string[];
+	resourceGroupId?: string;
 }): JobSpec {
 	// Validate required fields
 	if (!args.image) {
@@ -272,6 +273,7 @@ export function createJobSpec(args: {
 		environment,
 		secrets,
 		timeoutSeconds,
+		...(args.resourceGroupId ? { resourceGroupId: args.resourceGroupId } : {}),
 	};
 	if (volumes) {
 		spec.volumes = volumes;

--- a/packages/mcp/src/jobs/types.ts
+++ b/packages/mcp/src/jobs/types.ts
@@ -116,6 +116,8 @@ export interface JobSpec {
 	volumes?: JobVolume[];
 	labels?: Record<string, string>;
 	expose?: { ports: number[] };
+	/** Enterprise resource group used for billing attribution. */
+	resourceGroupId?: string;
 }
 
 /**
@@ -158,8 +160,15 @@ const commonArgsSchema = z.object({
 	namespace: z.string().optional().describe('Target namespace (username or organization). Defaults to current user.'),
 });
 
+const submissionArgsSchema = commonArgsSchema.extend({
+	resource_group_id: z
+		.string()
+		.optional()
+		.describe('Enterprise resource group ID for billing attribution. Requires its organization as namespace.'),
+});
+
 // Run command args
-export const runArgsSchema = commonArgsSchema.extend({
+export const runArgsSchema = submissionArgsSchema.extend({
 	image: z
 		.string()
 		.describe('Docker image or HF Space URL (e.g., "python:3.12" or "hf.co/spaces/user/space")')
@@ -200,7 +209,7 @@ export const runArgsSchema = commonArgsSchema.extend({
 });
 
 // UV command args
-export const uvArgsSchema = commonArgsSchema.extend({
+export const uvArgsSchema = submissionArgsSchema.extend({
 	script: z
 		.string()
 		.describe('Python script: local file path, URL, or inline code. UV will handle dependencies automatically.'),

--- a/packages/mcp/src/sandbox-tool.ts
+++ b/packages/mcp/src/sandbox-tool.ts
@@ -696,6 +696,7 @@ const SANDBOX_CREATE_FLAGS: CommandOptionMap = {
 	'--timeout': { key: 'timeout', kind: 'string' },
 	'--name': { key: 'name', kind: 'string' },
 	'--namespace': { key: 'namespace', kind: 'string' },
+	'--resource-group-id': { key: 'resource_group_id', kind: 'string' },
 	'--forward-hf-token': { key: 'forward_hf_token', kind: 'boolean' },
 	'--volume': { key: 'volumes', kind: 'string', repeatable: true },
 	'--bucket': { key: 'bucket', kind: 'string' },
@@ -715,7 +716,7 @@ const SANDBOX_DESCRIPTION = `Create and manage Hugging Face Sandboxes.
 
 Grammar; each token below is one args array element:
   create [--name NAME] [--image IMAGE] [--flavor FLAVOR] [--timeout DURATION]
-         [--namespace NAMESPACE] [--forward-hf-token] [--volume SPEC]...
+         [--namespace NAMESPACE] [--resource-group-id ID] [--forward-hf-token] [--volume SPEC]...
          [--bucket OWNER/NAME] [--bucket-mode ro|rw] [--bucket-mount-path PATH]
   status HANDLE
   terminate HANDLE
@@ -783,6 +784,7 @@ interface SandboxParams {
 	timeout?: string;
 	name?: string;
 	namespace?: string;
+	resource_group_id?: string;
 	forward_hf_token?: boolean;
 	volumes?: string[];
 	bucket?: string;
@@ -814,6 +816,7 @@ function parseSandboxRequest(request: HfSandboxParams): SandboxParams {
 		...(typeof options.timeout === 'string' ? { timeout: options.timeout } : {}),
 		...(typeof options.name === 'string' ? { name: options.name } : {}),
 		...(typeof options.namespace === 'string' ? { namespace: options.namespace } : {}),
+		...(typeof options.resource_group_id === 'string' ? { resource_group_id: options.resource_group_id } : {}),
 		...(options.forward_hf_token === true ? { forward_hf_token: true } : {}),
 		...(Array.isArray(options.volumes) ? { volumes: options.volumes } : {}),
 		...(typeof options.bucket === 'string' ? { bucket: options.bucket } : {}),
@@ -949,6 +952,9 @@ export class HfSandboxTool extends SandboxToolBase {
 	private async create(params: SandboxParams, options?: SandboxOptions): Promise<SandboxCreateResult> {
 		const name = params.name ?? generateName();
 		validateName(name);
+		if (params.resource_group_id && !params.namespace) {
+			throw new Error('EINVAL: --resource-group-id requires --namespace for the owning organization.');
+		}
 		await notifySandboxProgress(options, {
 			event: 'create',
 			message: `Creating sandbox ${name}: resolving namespace.`,
@@ -1001,6 +1007,7 @@ export class HfSandboxTool extends SandboxToolBase {
 			},
 			expose: { ports: [SANDBOX_PORT] },
 			volumes,
+			...(params.resource_group_id ? { resourceGroupId: params.resource_group_id } : {}),
 		};
 
 		await notifySandboxProgress(options, {

--- a/packages/mcp/test/jobs/command-translation.spec.ts
+++ b/packages/mcp/test/jobs/command-translation.spec.ts
@@ -436,5 +436,15 @@ describe('Jobs Command Translation', () => {
 
 			expect(spec).not.toHaveProperty('volumes');
 		});
+
+		it('should include a resource group for billing attribution', () => {
+			const spec = createJobSpec({
+				image: 'python:3.12',
+				command: ['echo', 'hi'],
+				resourceGroupId: '65f000000000000000000001',
+			});
+
+			expect(spec.resourceGroupId).toBe('65f000000000000000000001');
+		});
 	});
 });

--- a/packages/mcp/test/jobs/uv-command.spec.ts
+++ b/packages/mcp/test/jobs/uv-command.spec.ts
@@ -75,6 +75,37 @@ describe('uvCommand', () => {
 		expect(shellCommand).toContain('-p 3.12');
 	});
 
+	it('passes organization and resource group billing to the Jobs API', async () => {
+		const harness = setupMockClient();
+
+		await uvCommand(
+			{
+				script: 'print("billing")',
+				detach: true,
+				namespace: 'acme',
+				resource_group_id: '65f000000000000000000001',
+			},
+			harness.client
+		);
+
+		expect(harness.runJob).toHaveBeenCalledWith(
+			expect.objectContaining({ resourceGroupId: '65f000000000000000000001' }),
+			'acme'
+		);
+	});
+
+	it('requires an organization namespace with a resource group', async () => {
+		const harness = setupMockClient();
+
+		await expect(
+			uvCommand(
+				{ script: 'print("billing")', detach: true, resource_group_id: '65f000000000000000000001' },
+				harness.client
+			)
+		).rejects.toThrow(/requires the owning organization/);
+		expect(harness.runJob).not.toHaveBeenCalled();
+	});
+
 	it('reports job submission progress', async () => {
 		const harness = setupMockClient();
 		const onProgress = vi.fn().mockResolvedValue(undefined);

--- a/packages/mcp/test/sandbox-tool.spec.ts
+++ b/packages/mcp/test/sandbox-tool.spec.ts
@@ -206,6 +206,34 @@ describe('HfSandboxTool', () => {
 		);
 	});
 
+	it('attributes the backing Job to an organization resource group', async () => {
+		const jobsClient = createJobsClient();
+		const tool = new HfSandboxTool('hf-token', true, undefined, jobsClient, createRpcClient());
+
+		await tool.run({
+			cmd: 'create',
+			args: ['--namespace', 'acme', '--resource-group-id', '65f000000000000000000001'],
+		});
+
+		expect(jobsClient.runJob).toHaveBeenCalledWith(
+			expect.objectContaining({ resourceGroupId: '65f000000000000000000001' }),
+			'acme'
+		);
+	});
+
+	it('requires an organization namespace with a resource group', async () => {
+		const jobsClient = createJobsClient();
+		const tool = new HfSandboxTool('hf-token', true, undefined, jobsClient, createRpcClient());
+
+		await expect(
+			tool.run({
+				cmd: 'create',
+				args: ['--resource-group-id', '65f000000000000000000001'],
+			})
+		).rejects.toThrow(/requires --namespace/);
+		expect(jobsClient.runJob).not.toHaveBeenCalled();
+	});
+
 	it('emits startup progress while creating a sandbox', async () => {
 		const rpcClient = createRpcClient();
 		const tool = new HfSandboxTool('hf-token', true, 'evalstate', createJobsClient(), rpcClient);


### PR DESCRIPTION
A small PR that adds `resource_group_id` for Jobs `run`, `uv`, and scheduled submissions (disclosure: written with Codex).

Motivation: https://github.com/huggingface/chat-ui/pull/2571

Tests pass but I haven't tested this end-to-end locally (not sure if there's an easy way to do that, happy to do so if you can provide a pointer @evalstate)